### PR TITLE
Handle API retries without duplicate LLM calls

### DIFF
--- a/API/api_deepseek.py
+++ b/API/api_deepseek.py
@@ -154,11 +154,18 @@ def init_db():
                     status TEXT,
                     processing_time REAL,
                     data_size INTEGER,
+                    scan_hash TEXT UNIQUE,
                     scan_data TEXT,
                     analysis_result TEXT,
                     embedding vector(768)
                 )
                 """
+            )
+            cur.execute(
+                "ALTER TABLE resultscan ADD COLUMN IF NOT EXISTS scan_hash TEXT UNIQUE"
+            )
+            cur.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS resultscan_scan_hash_idx ON resultscan(scan_hash)"
             )
         PG_CONN.commit()
     except Exception:
@@ -187,7 +194,7 @@ def log_request(client_ip, status, processing_time, data_size):
         logging.exception("Erro registrando requisição")
 
 
-def save_log_to_db(client_ip, status, processing_time, data_size, scan_data, result):
+def save_log_to_db(client_ip, status, processing_time, data_size, scan_data, result, scan_hash):
     """
     Persiste o log da análise na tabela resultscan.
     """
@@ -198,15 +205,16 @@ def save_log_to_db(client_ip, status, processing_time, data_size, scan_data, res
         with PG_CONN.cursor() as cur:
             cur.execute("""
                 INSERT INTO resultscan
-                  (timestamp, client_ip, status, processing_time, data_size, scan_data, analysis_result, embedding)
+                  (timestamp, client_ip, status, processing_time, data_size, scan_hash, scan_data, analysis_result, embedding)
                 VALUES
-                  (%s, %s, %s, %s, %s, %s, %s, %s)
+                  (%s, %s, %s, %s, %s, %s, %s, %s, %s)
             """, (
                 datetime.utcnow(),
                 client_ip,
                 status,
                 processing_time,
                 data_size,
+                scan_hash,
                 scan_data,
                 result,
                 embedding_str
@@ -258,6 +266,25 @@ def clean_analysis_result(text):
 
 analysis_cache = OrderedDict()  # Cache LRU para evitar reprocessamento
 
+def compute_scan_hash(text: str) -> str:
+    """Retorna um hash CRC32 em formato string para o texto fornecido."""
+    return str(zlib.crc32(text.encode("utf-8")))
+
+def get_cached_result_from_db(scan_hash: str):
+    """Busca resultado previamente processado no banco pelo hash."""
+    try:
+        with PG_CONN.cursor() as cur:
+            cur.execute(
+                "SELECT analysis_result FROM resultscan WHERE scan_hash = %s LIMIT 1",
+                (scan_hash,),
+            )
+            row = cur.fetchone()
+            if row:
+                return row[0]
+    except Exception:
+        logging.exception("Erro consultando resultado em cache")
+    return None
+
 def profile_if_enabled(func):
     def wrapper(*args, **kwargs):
         if ENABLE_PROFILING:
@@ -286,7 +313,7 @@ def cache_set(key, value):
         analysis_cache.popitem(last=False)
 
 @profile_if_enabled
-def process_analysis(scan_data, context):
+def process_analysis(scan_data, context, scan_hash):
     """
     Executa a análise utilizando o modelo selecionado via Ollama.
     - Gera uma chave CRC32 para cache.
@@ -295,7 +322,7 @@ def process_analysis(scan_data, context):
     """
     start_time = datetime.now()
     input_message = f"{context}\n\nDados do Scan:\n{scan_data}"
-    cache_key = zlib.crc32(input_message.encode('utf-8'))
+    cache_key = scan_hash
     
     cached = cache_get(cache_key)
     if cached is not None:
@@ -353,6 +380,7 @@ if USE_PYDANTIC:
         scan_data: str
         context: str
         callback_url: str | None = None
+        scan_hash: str | None = None
 
 # ---------------------- ROTAS ----------------------
 @app.route("/analyze", methods=["POST"])
@@ -388,6 +416,7 @@ def analyze():
             scan_data = payload.scan_data
             context = payload.context
             callback_url = payload.callback_url
+            scan_hash = payload.scan_hash if hasattr(payload, 'scan_hash') else compute_scan_hash(scan_data)
         else:
             data = json.loads(json_data)
             if 'scan_data' not in data or 'context' not in data:
@@ -395,16 +424,28 @@ def analyze():
             scan_data = data['scan_data']
             context = data['context']
             callback_url = data.get('callback_url')
+            scan_hash = data.get('scan_hash', compute_scan_hash(scan_data))
+
+        cached_result = get_cached_result_from_db(scan_hash)
+        if cached_result is not None:
+            processing_time = (datetime.now() - start_time).total_seconds()
+            log_request(client_ip, 'cached', processing_time, data_size)
+            console.print('[CACHE] Resultado obtido do banco.', style='bold cyan')
+            return jsonify({
+                'analysis': cached_result,
+                'processing_time': 0,
+                'cached': True
+            }), 200
 
         console.print("[*] Processando análise...", style="bold yellow")
-        result = process_analysis(scan_data, context)
+        result = process_analysis(scan_data, context, scan_hash)
         processing_time = (datetime.now() - start_time).total_seconds()
         status = "success"
 
         # Novo log da análise completa
         log_analysis(client_ip, status, processing_time, data_size, result)
         # gravação no banco relacional (agora síncrona)
-        save_log_to_db(client_ip, status, processing_time, data_size, scan_data, result)
+        save_log_to_db(client_ip, status, processing_time, data_size, scan_data, result, scan_hash)
 
         if not callback_url:
             log_request(client_ip, status, processing_time, data_size)

--- a/SCAN/nmap_api_client.py
+++ b/SCAN/nmap_api_client.py
@@ -39,6 +39,7 @@ import subprocess
 import json
 import re
 import socket
+import zlib
 from dotenv import load_dotenv, find_dotenv
 
 # Load environment variables from a .env file if present
@@ -627,9 +628,12 @@ def send_to_deepseek(scan_data, max_attempts: int = 5, wait_seconds: int = 5):
     ou quando o número máximo de tentativas for atingido.
     """
 
+    # Usa hash CRC32 do scan para permitir deduplicação no servidor
+    scan_hash = str(zlib.crc32(scan_data.encode("utf-8")))
     payload = {
         "scan_data": scan_data,
         "context": CONTEXT_Exploracao,
+        "scan_hash": scan_hash,
     }
     headers = {"X-API-Key": API_KEY}
 


### PR DESCRIPTION
## Summary
- send a CRC32 hash with each scan result to deduplicate processing
- add deduplication logic on the API server

## Testing
- `python -m py_compile SCAN/nmap_api_client.py API/api_deepseek.py`

------
https://chatgpt.com/codex/tasks/task_e_6840a7b6bcf0832a84c8700832040c7f