### PR TITLE
Fix dotenv path for consistent configuration

### DIFF
--- a/API/api_deepseek.py
+++ b/API/api_deepseek.py
@@ -21,11 +21,12 @@ import re
 import zlib
 import requests
 from collections import OrderedDict
-from dotenv import load_dotenv, find_dotenv
+from dotenv import load_dotenv
 
 
-# Load environment variables from a .env file if present
-load_dotenv(find_dotenv())
+# Load environment variables from the project root
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+load_dotenv(os.path.join(BASE_DIR, ".env"))
 
 from datetime import datetime
 from flask import Flask, request, jsonify

--- a/SCAN/nmap_api_client.py
+++ b/SCAN/nmap_api_client.py
@@ -39,10 +39,11 @@ import subprocess
 import json
 import re
 import socket
-from dotenv import load_dotenv, find_dotenv
+from dotenv import load_dotenv
 
-# Load environment variables from a .env file if present
-load_dotenv(find_dotenv())
+# Load environment variables from the project root
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+load_dotenv(os.path.join(BASE_DIR, ".env"))
 from datetime import datetime
 import requests
 from rich.console import Console


### PR DESCRIPTION
## Summary
- ensure API and client load `.env` from project root

## Testing
- `python -m py_compile API/api_deepseek.py SCAN/nmap_api_client.py`


------
https://chatgpt.com/codex/tasks/task_e_684104bcdc68832aac822e42685c0644