### PR TITLE
Make SBERT model configurable via env

### DIFF
--- a/.env.exemple
+++ b/.env.exemple
@@ -11,8 +11,8 @@ CACHE_MAX_SIZE=128
 ENABLE_PROFILING=false
 GUNICORN_WORKERS=4
 
-# Modelo de IA instalado no Ollama
-SBERT_MODEL_NAME=deepseek-r1
+# Modelo SBERT para gerar embeddings (opcional)
+SBERT_MODEL_NAME=sentence-transformers/all-mpnet-base-v2
 # Modelos instalados separados por vírgula (opcional)
 OLLAMA_MODELS="deepseek-r1:14b,deepseek-r1:8b,qwen3:0.6b,qwen3:1.7b,qwen2.5-coder:32b,qwen2.5-coder:14b,qwen2.5:32b,qwen3:14b,deepseek-r1:32b,qwen3:32b,qwen3:8b,qwen2.5:7b,deepseek-r1:1.5b,gemma3:27b,llama3.2:3b,phi4:14b"
 

--- a/API/api_deepseek.py
+++ b/API/api_deepseek.py
@@ -48,7 +48,10 @@ if not all([PG_HOST, PG_DB, PG_USER, PG_PASS]):
 PG_CONN = psycopg2.connect(host=PG_HOST, dbname=PG_DB, user=PG_USER, password=PG_PASS)
 
 # Modelo de embeddings para armazenamento vetorial
-_embedder = SentenceTransformer("sentence-transformers/all-mpnet-base-v2")
+SBERT_MODEL_NAME = os.getenv(
+    "SBERT_MODEL_NAME", "sentence-transformers/all-mpnet-base-v2"
+)
+_embedder = SentenceTransformer(SBERT_MODEL_NAME)
 # Habilita profiling condicional
 ENABLE_PROFILING = os.getenv("ENABLE_PROFILING", "false").lower() == "true"
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ CACHE_MAX_SIZE=128
 ENABLE_PROFILING=false
 GUNICORN_WORKERS=4
 
-# Modelo de IA instalado no Ollama
-SBERT_MODEL_NAME=deepseek-r1
+# Modelo SBERT para gerar embeddings (opcional)
+SBERT_MODEL_NAME=sentence-transformers/all-mpnet-base-v2
 # Modelos instalados separados por vírgula (opcional)
 OLLAMA_MODELS="deepseek-r1:14b,deepseek-r1:8b,qwen3:0.6b,qwen3:1.7b,qwen2.5-coder:32b,qwen2.5-coder:14b,qwen2.5:32b,qwen3:14b,deepseek-r1:32b,qwen3:32b,qwen3:8b,qwen2.5:7b,deepseek-r1:1.5b,gemma3:27b,llama3.2:3b,phi4:14b"
 
@@ -206,16 +206,16 @@ Abra `report.html` no navegador para visualizar gráficos e tabelas.
 
 ## :bulb: Exemplos de Uso
 
-### Escolher Modelo “deepseek-r1” via Ollama
+### Escolher Modelo SBERT padrão
 
 ```bash
-ollama pull deepseek-r1
+ollama pull sentence-transformers/all-mpnet-base-v2
 ```
 
 No `.env`:
 
 ```ini
-SBERT_MODEL_NAME=deepseek-r1
+SBERT_MODEL_NAME=sentence-transformers/all-mpnet-base-v2
 ```
 
 ### Utilizar Outro Modelo Personalizado


### PR DESCRIPTION
## Summary
- read `SBERT_MODEL_NAME` from environment in the DeepSeek API
- update README to explain the SBERT_MODEL_NAME variable
- adjust `.env.exemple` with default SBERT model

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68506f7e2960832ab04af4bb9dcff2d4