### PR TITLE
Fix duplicate import in api_deepseek

### DIFF
--- a/API/api_deepseek.py
+++ b/API/api_deepseek.py
@@ -36,7 +36,6 @@ from sentence_transformers import SentenceTransformer
 
 # Salvando no PostgreSQL
 import psycopg2
-from datetime import datetime
 
 # Configuração do PostgreSQL via variáveis de ambiente
 PG_HOST = os.environ.get("PG_HOST")


### PR DESCRIPTION
## Summary
- remove duplicate `from datetime import datetime` line in `api_deepseek.py`

## Testing
- `python -m py_compile API/api_deepseek.py`


------
https://chatgpt.com/codex/tasks/task_e_685071456bc8832a94b23300cbb86ec0