### PR TITLE
Add requirements and update README setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,11 @@ Menu interativo para seleção das ferramentas e ordem de execução. Logs padro
 
 ### Instale as dependências Python
 
+Use o `requirements.txt` para instalar todas as bibliotecas necessárias:
+
 ```bash
-pip install sentence-transformers psycopg2-binary pgvector python-dotenv
+pip install -r requirements.txt
+# ou execute ./init-env.sh para criar o virtualenv automaticamente
 ```
 
 ### Instale o Ollama

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+python-dotenv
+Flask
+requests
+rich
+sentence-transformers
+psycopg2-binary
+pgvector
+pydantic
+flask-compress


### PR DESCRIPTION
## Summary
- list packages for API and SCAN tools in requirements.txt
- document installing dependencies via requirements.txt or `./init-env.sh`

## Testing
- `python3 -m py_compile API/api_deepseek.py SCAN/nmap_api_client.py`

------
https://chatgpt.com/codex/tasks/task_e_685076afa1ac832a8c49a8c9b37d3f19