### PR TITLE
Improve error message when loading SentenceTransformer

### DIFF
--- a/API/api_deepseek.py
+++ b/API/api_deepseek.py
@@ -50,7 +50,13 @@ PG_CONN = psycopg2.connect(host=PG_HOST, dbname=PG_DB, user=PG_USER, password=PG
 SBERT_MODEL_NAME = os.getenv(
     "SBERT_MODEL_NAME", "sentence-transformers/all-mpnet-base-v2"
 )
-_embedder = SentenceTransformer(SBERT_MODEL_NAME)
+try:
+    _embedder = SentenceTransformer(SBERT_MODEL_NAME)
+except OSError as exc:  # Usually raised when the model cannot be downloaded
+    raise RuntimeError(
+        "Falha ao carregar o modelo SBERT. Defina SBERT_MODEL_NAME com um nome de modelo v\u00e1lido "
+        "ou execute 'huggingface-cli login' para acessar modelos privados."
+    ) from exc
 # Habilita profiling condicional
 ENABLE_PROFILING = os.getenv("ENABLE_PROFILING", "false").lower() == "true"
 


### PR DESCRIPTION
## Summary
- catch `OSError` when loading the SBERT model in `api_deepseek.py`
- raise a RuntimeError that instructs the user to specify a valid `SBERT_MODEL_NAME` or login to Hugging Face

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b6598774832aba6b52535f89499c