### PR TITLE
Clarify SBERT model usage

### DIFF
--- a/API/README.md
+++ b/API/README.md
@@ -75,7 +75,7 @@ curl -X POST http://localhost:5000/analyze \
 - Utilize um **reverso proxy** (como Nginx ou Traefik) para expor a API de forma segura.
 - Configure um **firewall** para restringir acessos indesejados.
 - Utilize **variáveis de ambiente** para armazenar a API Key de forma segura.
-- Defina `SBERT_MODEL_NAME` com um modelo válido do [Hugging Face](https://huggingface.co) caso deseje gerar embeddings.
+- Defina `SBERT_MODEL_NAME` com um modelo existente do [Sentence Transformers](https://huggingface.co/sentence-transformers). Se o modelo for privado no Hugging Face, autentique-se (por exemplo, com `huggingface-cli login`) antes do download. Consulte o [README principal](../README.md) para mais detalhes.
 
 Este projeto é um ponto de partida para uma integração robusta com DeepSeek e pode ser expandido conforme as necessidades da aplicação.
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ EMAIL_SENDER=seu@email.com
 EMAIL_RECIPIENT=destino@email.com
 ```
 
+> **Obs.:** `SBERT_MODEL_NAME` deve referenciar um modelo existente do [Sentence Transformers](https://huggingface.co/sentence-transformers). Se o modelo for privado no Hugging Face, autentique-se com `huggingface-cli login` ou informe seu token para que o download seja autorizado.
+
 ---
 
 ## :computer: Como Executar


### PR DESCRIPTION
## Summary
- explain that `SBERT_MODEL_NAME` must point to a valid Sentence Transformers model and may require Hugging Face auth
- cross-reference root instructions in API README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b78ba4a8832ab3de1180ebb2d8a2