### PR TITLE
Include SecurityLLM in model selection menu

### DIFF
--- a/API/api_deepseek.py
+++ b/API/api_deepseek.py
@@ -69,11 +69,17 @@ SELECTED_MODEL = os.getenv("OLLAMA_SELECTED_MODEL", "deepseek-r1:32b")
 LLM_BACKEND = os.getenv("LLM_BACKEND", "ollama").lower()
 # Modelo Hugging Face a ser utilizado quando o backend for "huggingface"
 HF_MODEL_NAME = os.getenv("HF_MODEL_NAME", "ZySec-AI/SecurityLLM")
+HF_PIPELINE = None
+
+def load_hf_pipeline(model_name: str):
+    """Carrega o pipeline Hugging Face para o modelo especificado."""
+    global HF_PIPELINE
+    from transformers import pipeline
+    HF_PIPELINE = pipeline("text-generation", model=model_name)
 
 if LLM_BACKEND == "huggingface":
     try:
-        from transformers import pipeline
-        HF_PIPELINE = pipeline("text-generation", model=HF_MODEL_NAME)
+        load_hf_pipeline(HF_MODEL_NAME)
     except Exception as exc:
         raise RuntimeError(
             f"Falha ao carregar o modelo Hugging Face {HF_MODEL_NAME}: {exc}"
@@ -521,42 +527,55 @@ def create_app():
 
 # ---------------------- ENTRY POINT (DESENVOLVIMENTO) ----------------------
 if __name__ == "__main__":
-    if LLM_BACKEND == "ollama":
-        # Permite definir a lista de modelos via variável de ambiente OLLAMA_MODELS
-        env_models = os.getenv("OLLAMA_MODELS")
-        if env_models:
-            available_models = [m.strip() for m in env_models.split(",") if m.strip()]
-        else:
-            # Lista padrão de modelos (ordenados alfabeticamente)
-            available_models = [
-                "deepseek-r1:1.5b",
-                "deepseek-r1:14b",
-                "deepseek-r1:32b",
-                "qwen2.5:7b",
-                "qwen2.5:14b",
-                "qwen2.5:32b",
-                "qwen3:14b",
-                "qwen3:32b",
-                "qwen3:8b",
-            ]
-
-        print("Escolha o modelo para análise (ordenados por nome):")
-        for i, model in enumerate(available_models, 1):
-            print(f"{i}) {model}")
-
-        try:
-            choice = int(input(f"Digite uma opção (1 a {len(available_models)}): ").strip())
-            if 1 <= choice <= len(available_models):
-                SELECTED_MODEL = available_models[choice-1]
-            else:
-                raise ValueError
-        except (ValueError, IndexError):
-            SELECTED_MODEL = "deepseek-r1:32b"
-            console.print("Opção inválida, usando deepseek-r1:32b como padrão", style="bold red")
-
-        console.print(f"Modelo selecionado: {SELECTED_MODEL}", style="bold cyan")
+    # Permite definir a lista de modelos via variável de ambiente OLLAMA_MODELS
+    env_models = os.getenv("OLLAMA_MODELS")
+    if env_models:
+        available_models = [m.strip() for m in env_models.split(",") if m.strip()]
     else:
-        console.print(f"Utilizando modelo Hugging Face: {HF_MODEL_NAME}", style="bold cyan")
+        # Lista padrão de modelos (ordenados alfabeticamente)
+        available_models = [
+            "deepseek-r1:1.5b",
+            "deepseek-r1:14b",
+            "deepseek-r1:32b",
+            "qwen2.5:7b",
+            "qwen2.5:14b",
+            "qwen2.5:32b",
+            "qwen3:14b",
+            "qwen3:32b",
+            "qwen3:8b",
+        ]
+
+    # Adiciona o modelo Hugging Face ao menu, se ainda não estiver listado
+    if HF_MODEL_NAME not in available_models:
+        available_models.append(HF_MODEL_NAME)
+
+    print("Escolha o modelo para análise (ordenados por nome):")
+    for i, model in enumerate(available_models, 1):
+        print(f"{i}) {model}")
+
+    try:
+        choice = int(input(f"Digite uma opção (1 a {len(available_models)}): ").strip())
+        if 1 <= choice <= len(available_models):
+            chosen_model = available_models[choice-1]
+        else:
+            raise ValueError
+    except (ValueError, IndexError):
+        chosen_model = "deepseek-r1:32b"
+        console.print("Opção inválida, usando deepseek-r1:32b como padrão", style="bold red")
+
+    if chosen_model == HF_MODEL_NAME:
+        LLM_BACKEND = "huggingface"
+        HF_MODEL_NAME = chosen_model
+        try:
+            load_hf_pipeline(HF_MODEL_NAME)
+        except Exception as exc:
+            console.print(f"[-] Falha ao carregar modelo Hugging Face: {exc}", style="bold red")
+            sys.exit(1)
+        console.print(f"Modelo selecionado (Hugging Face): {HF_MODEL_NAME}", style="bold cyan")
+    else:
+        LLM_BACKEND = "ollama"
+        SELECTED_MODEL = chosen_model
+        console.print(f"Modelo selecionado (Ollama): {SELECTED_MODEL}", style="bold cyan")
 
     local_app = create_app()
     try:


### PR DESCRIPTION
## Summary
- allow loading Hugging Face model pipeline dynamically
- extend interactive menu to list ZySec-AI/SecurityLLM alongside Ollama models

## Testing
- `python3 -m py_compile API/api_deepseek.py SCAN/nmap_api_client.py`

------
https://chatgpt.com/codex/tasks/task_e_685da3dac888832aa1ac73464af78b98