### PR TITLE
Add menu for CPU/GPU selection

### DIFF
--- a/API/api_deepseek.py
+++ b/API/api_deepseek.py
@@ -23,6 +23,13 @@ import requests
 from collections import OrderedDict
 from dotenv import load_dotenv
 
+# Verifica disponibilidade de GPU (CUDA)
+try:
+    import torch
+    CUDA_AVAILABLE = torch.cuda.is_available()
+except Exception:
+    CUDA_AVAILABLE = False
+
 
 # Load environment variables from the project root
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -70,16 +77,24 @@ LLM_BACKEND = os.getenv("LLM_BACKEND", "ollama").lower()
 # Modelo Hugging Face a ser utilizado quando o backend for "huggingface"
 HF_MODEL_NAME = os.getenv("HF_MODEL_NAME", "ZySec-AI/SecurityLLM")
 HF_PIPELINE = None
+HF_DEVICE_ENV = os.getenv("HF_DEVICE")
+if HF_DEVICE_ENV is not None:
+    try:
+        HF_DEVICE = int(HF_DEVICE_ENV)
+    except ValueError:
+        HF_DEVICE = 0 if CUDA_AVAILABLE else -1
+else:
+    HF_DEVICE = 0 if CUDA_AVAILABLE else -1
 
-def load_hf_pipeline(model_name: str):
+def load_hf_pipeline(model_name: str, device: int = HF_DEVICE):
     """Carrega o pipeline Hugging Face para o modelo especificado."""
     global HF_PIPELINE
     from transformers import pipeline
-    HF_PIPELINE = pipeline("text-generation", model=model_name)
+    HF_PIPELINE = pipeline("text-generation", model=model_name, device=device)
 
 if LLM_BACKEND == "huggingface":
     try:
-        load_hf_pipeline(HF_MODEL_NAME)
+        load_hf_pipeline(HF_MODEL_NAME, HF_DEVICE)
     except Exception as exc:
         raise RuntimeError(
             f"Falha ao carregar o modelo Hugging Face {HF_MODEL_NAME}: {exc}"
@@ -566,12 +581,41 @@ if __name__ == "__main__":
     if chosen_model == HF_MODEL_NAME:
         LLM_BACKEND = "huggingface"
         HF_MODEL_NAME = chosen_model
+
+        device_options = ["CPU"]
+        if CUDA_AVAILABLE:
+            device_options.append("GPU")
+
+        if len(device_options) > 1:
+            print("Escolha o hardware para execução do modelo:")
+            for i, opt in enumerate(device_options, 1):
+                print(f"{i}) {opt}")
+            try:
+                device_choice = int(input(f"Digite uma opção (1 a {len(device_options)}): ").strip())
+                if 1 <= device_choice <= len(device_options):
+                    chosen_device = device_options[device_choice-1]
+                else:
+                    raise ValueError
+            except (ValueError, IndexError):
+                chosen_device = "GPU" if CUDA_AVAILABLE else "CPU"
+                console.print(
+                    f"Opção inválida, usando {chosen_device} como padrão",
+                    style="bold red",
+                )
+        else:
+            chosen_device = "CPU"
+
+        HF_DEVICE = 0 if chosen_device == "GPU" else -1
+
         try:
-            load_hf_pipeline(HF_MODEL_NAME)
+            load_hf_pipeline(HF_MODEL_NAME, HF_DEVICE)
         except Exception as exc:
             console.print(f"[-] Falha ao carregar modelo Hugging Face: {exc}", style="bold red")
             sys.exit(1)
-        console.print(f"Modelo selecionado (Hugging Face): {HF_MODEL_NAME}", style="bold cyan")
+        console.print(
+            f"Modelo selecionado (Hugging Face): {HF_MODEL_NAME} ({chosen_device})",
+            style="bold cyan",
+        )
     else:
         LLM_BACKEND = "ollama"
         SELECTED_MODEL = chosen_model


### PR DESCRIPTION
## Summary
- detect CUDA availability on startup
- allow setting HF_DEVICE via env var
- load huggingface pipeline with explicit device
- provide menu to pick CPU or GPU when launching in CLI mode

## Testing
- `python3 -m py_compile API/api_deepseek.py`


------
https://chatgpt.com/codex/tasks/task_e_685da7efb248832ab9877a4457fe8688