### PR TITLE
Allow runtime backend selection

### DIFF
--- a/API/api_deepseek.py
+++ b/API/api_deepseek.py
@@ -22,6 +22,7 @@ import zlib
 import requests
 from collections import OrderedDict
 from dotenv import load_dotenv
+import argparse
 
 # Verifica disponibilidade de GPU (CUDA)
 try:
@@ -548,6 +549,17 @@ def create_app():
 
 # ---------------------- ENTRY POINT (DESENVOLVIMENTO) ----------------------
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Servidor de analise de scans")
+    parser.add_argument(
+        "-b",
+        "--backend",
+        choices=["ollama", "huggingface"],
+        help="Backend do modelo (ollama ou huggingface)",
+    )
+    args = parser.parse_args()
+    if args.backend:
+        LLM_BACKEND = args.backend
+
     # Permite definir a lista de modelos via variável de ambiente OLLAMA_MODELS
     env_models = os.getenv("OLLAMA_MODELS")
     if env_models:

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ LLM_BACKEND=ollama
 # Lista de modelos Hugging Face (separados por vírgula)
 HUGGINGFACE="ZySec-AI/SecurityLLM"
 
+# Também é possível definir o backend na linha de comando:
+#
+# ```bash
+# python3 API/api_deepseek.py --backend huggingface
+# ```
+
 # Configurações de API do Ollama (opcional)
 # OLLAMA_HOST=localhost
 # OLLAMA_PORT=11434


### PR DESCRIPTION
## Summary
- allow selecting backend via command line argument
- document new `--backend` option in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686182b8b084832aabecb810734d717c