### PR TITLE
Fix progress monitor duplication

### DIFF
--- a/API/llm_api_server.py
+++ b/API/llm_api_server.py
@@ -160,6 +160,14 @@ executor = ThreadPoolExecutor(max_workers=MAX_WORKERS)
 active_tasks: dict[str, float] = {}
 task_lock = Lock()
 
+# Habilita ou desabilita o monitor de progresso. Por padrão ele é ativado
+# apenas quando a saída está ligada a um terminal interativo.
+ENABLE_PROGRESS_MONITOR = (
+    os.getenv("ENABLE_PROGRESS_MONITOR", "true" if sys.stdout.isatty() else "false")
+    .lower()
+    == "true"
+)
+
 def monitor_progress():
     """Exibe tabela de progresso das tarefas em execução."""
     with Live(refresh_per_second=5, console=console) as live:
@@ -182,7 +190,10 @@ console = Console()
 progress_thread = None
 
 def start_progress_monitor():
-    """Inicia a tela de monitoramento de tarefas se ainda não estiver ativa."""
+    """Inicia a tela de monitoramento de tarefas se habilitada."""
+    if not ENABLE_PROGRESS_MONITOR:
+        return
+
     global progress_thread
     if progress_thread is None or not progress_thread.is_alive():
         progress_thread = Thread(target=monitor_progress, daemon=True)
@@ -595,7 +606,6 @@ def create_app():
     Inicializa o banco de dados e verifica a disponibilidade do modelo via Ollama.
     """
     init_db()
-    start_progress_monitor()
     if not test_model():
         console.print(
             f"[-] Modelo {HF_MODEL_NAME if LLM_BACKEND!='ollama' else SELECTED_MODEL} não disponível!",


### PR DESCRIPTION
## Summary
- ensure progress monitor only runs when enabled
- avoid starting progress thread during `create_app`

## Testing
- `python -m py_compile API/llm_api_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68619bb7cc50832a8eeb8205d57ea2f3