### PR TITLE
Generate corporate HTML reports

### DIFF
--- a/report_menu.py
+++ b/report_menu.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import psycopg2
 from rich.console import Console
 from rich.table import Table
+from html import escape
 
 # Obtém parâmetros do banco de dados a partir de variáveis de ambiente
 PG_HOST = os.environ.get("PG_HOST")
@@ -81,6 +82,43 @@ def print_report(record):
     console.print("=" * 60)
 
 
+def save_html_report(record):
+    """Gera e salva o relatório em formato HTML."""
+    sanitized_id = str(record.get("id", "relatorio"))
+    filename = f"relatorio_{sanitized_id}.html"
+    html = f"""<html>
+    <head>
+        <meta charset='utf-8'>
+        <title>Relatório de Scan {sanitized_id}</title>
+        <style>
+            body {{ font-family: Arial, sans-serif; background-color: #f8f9fa; color: #333; }}
+            header {{ background-color: #1a237e; color: #fff; padding: 20px; text-align: center; }}
+            footer {{ background-color: #1a237e; color: #fff; text-align: center; padding: 10px; }}
+            .section {{ margin: 20px; padding: 15px; background-color: #fff; border: 1px solid #ddd; border-radius: 5px; }}
+            pre {{ white-space: pre-wrap; word-wrap: break-word; }}
+        </style>
+    </head>
+    <body>
+        <header>
+            <h1>Relatório de Scan</h1>
+            <p>ID: {escape(str(record['id']))} | Data: {escape(str(record['timestamp']))} | Alvo: {escape(record['ip_dominio_alvo'] or '-')}</p>
+        </header>
+        <div class='section'>
+            <h2>Dados do Scan</h2>
+            <pre>{escape(record['scan_data'] or '-')}</pre>
+        </div>
+        <div class='section'>
+            <h2>Análise da IA</h2>
+            <pre>{escape(record['analysis_result'] or '-')}</pre>
+        </div>
+        <footer>Relatório gerado em {datetime.now().isoformat()}</footer>
+    </body>
+    </html>"""
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(html)
+    console.print(f"[green]Relatório HTML salvo em {filename}[/green]")
+
+
 def main_menu():
     """Loop principal de seleção e impressão de relatórios."""
     while True:
@@ -109,6 +147,7 @@ def main_menu():
             console.print("[!] Registro não encontrado.", style="red")
             continue
         print_report(record)
+        save_html_report(record)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- produce HTML report files with simple corporate styling
- show save location after exporting HTML

## Testing
- `python3 -m py_compile report_menu.py`

------
https://chatgpt.com/codex/tasks/task_e_686296b86660832abde5dad695cab8ee