### PR TITLE
Improve HTML report organization

### DIFF
--- a/report_menu.py
+++ b/report_menu.py
@@ -85,11 +85,18 @@ def print_report(record):
 def save_html_report(record):
     """Gera e salva o relatório em formato HTML."""
     sanitized_id = str(record.get("id", "relatorio"))
-    filename = f"relatorio_{sanitized_id}.html"
+    target = record.get("ip_dominio_alvo") or "alvo_desconhecido"
+    sanitized_target = "".join(c if c.isalnum() or c in "-_." else "_" for c in target)
+
+    base_dir = os.path.join("reports", sanitized_target)
+    os.makedirs(base_dir, exist_ok=True)
+
+    filename = os.path.join(base_dir, f"relatorio_{sanitized_id}.html")
+    html_title = escape(target)
     html = f"""<html>
     <head>
         <meta charset='utf-8'>
-        <title>Relatório de Scan {sanitized_id}</title>
+        <title>{html_title}</title>
         <style>
             body {{ font-family: Arial, sans-serif; background-color: #f8f9fa; color: #333; }}
             header {{ background-color: #1a237e; color: #fff; padding: 20px; text-align: center; }}
@@ -100,8 +107,8 @@ def save_html_report(record):
     </head>
     <body>
         <header>
-            <h1>Relatório de Scan</h1>
-            <p>ID: {escape(str(record['id']))} | Data: {escape(str(record['timestamp']))} | Alvo: {escape(record['ip_dominio_alvo'] or '-')}</p>
+            <h1>{html_title}</h1>
+            <p>ID: {escape(str(record['id']))} | Data: {escape(str(record['timestamp']))} | Alvo: {escape(target)}</p>
         </header>
         <div class='section'>
             <h2>Dados do Scan</h2>


### PR DESCRIPTION
## Summary
- organize HTML output inside `reports/<ip_dominio_alvo>` directories
- use the target value as the HTML title

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68629a707394832a813a9c5dbfedaa36