### PR TITLE
Improve report generation

### DIFF
--- a/report_menu.py
+++ b/report_menu.py
@@ -91,7 +91,7 @@ def save_html_report(record):
     base_dir = os.path.join("reports", sanitized_target)
     os.makedirs(base_dir, exist_ok=True)
 
-    filename = os.path.join(base_dir, f"relatorio_{sanitized_id}.html")
+    filename = os.path.join(base_dir, f"relatorio_{sanitized_id}_{sanitized_target}.html")
     html_title = escape(target)
     html = f"""<html>
     <head>
@@ -157,5 +157,31 @@ def main_menu():
         save_html_report(record)
 
 
+def export_all_records():
+    """Gera relatórios HTML para todos os registros."""
+    records = list_records()
+    if not records:
+        console.print("[*] Nenhum registro encontrado.", style="yellow")
+        return
+    for rid, _, _ in records:
+        record = get_record(rid)
+        if record:
+            save_html_report(record)
+    console.print(f"[green]Exportação concluída: {len(records)} arquivos gerados.[/green]")
+
+
 if __name__ == "__main__":
-    main_menu()
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Menu de relatórios")
+    parser.add_argument(
+        "--export-all",
+        action="store_true",
+        help="Exporta relatórios HTML para todos os registros",
+    )
+    args = parser.parse_args()
+
+    if args.export_all:
+        export_all_records()
+    else:
+        main_menu()


### PR DESCRIPTION
## Summary
- allow exporting all DB records via `--export-all`
- include target info in report filenames

## Testing
- `python -m py_compile report_menu.py`

------
https://chatgpt.com/codex/tasks/task_e_68629bcecc90832a963d13c6e0baeddb