### PR TITLE
Improve IP tracking for pentest logs

### DIFF
--- a/SCAN/multi_scan_client.py
+++ b/SCAN/multi_scan_client.py
@@ -205,7 +205,7 @@ NETWORK_DEVICES_FILE = "network_devices.txt"
 console = Console()
 setup_signal_protection(console)
 
-def save_to_json(timestamp, target, combined_output, analyses):
+def save_to_json(timestamp, target, pentest_ip, target_ip, combined_output, analyses):
     """
     Insere um novo registro no arquivo JSON (results.json).
     Se o arquivo não existir, cria um array; caso exista, carrega e adiciona ao final.
@@ -213,8 +213,10 @@ def save_to_json(timestamp, target, combined_output, analyses):
     record = {
         "timestamp": timestamp,
         "target": target,
+        "pentest_ip": pentest_ip,
+        "target_ip": target_ip,
         "combined_output": combined_output,
-        "analysis": analyses
+        "analysis": analyses,
     }
 
     # Carrega registros existentes (se houver)
@@ -390,6 +392,17 @@ def get_server_ip(target):
     except Exception as e:
         console.print(f"[-] Erro ao resolver IP para {target}: {e}", style="bold red")
         return None
+
+def get_local_ip():
+    """Retorna o IP da máquina que está executando o pentest."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("8.8.8.8", 80))
+        return s.getsockname()[0]
+    except Exception:
+        return "127.0.0.1"
+    finally:
+        s.close()
 
 def run_nikto_scan(target):
     """
@@ -686,7 +699,13 @@ def run_scans_sequential(target):
     
     Retorna um dicionário com os outputs e as análises individuais.
     """
-    tool_results = {"target": target}
+    pentest_ip = get_local_ip()
+    target_ip = get_server_ip(target)
+    tool_results = {
+        "target": target,
+        "pentest_ip": pentest_ip,
+        "target_ip": target_ip or target,
+    }
     
     # 1) Nmap
     console.print("\n=== Iniciando scan Nmap ===", style="bold blue")
@@ -695,7 +714,7 @@ def run_scans_sequential(target):
     tool_results["nmap_analysis"] = send_to_deepseek(nmap_output, target)
     
     # 2) Nmap adicional para IP (se aplicável)
-    ip_address = get_server_ip(target)
+    ip_address = target_ip
     if ip_address and ip_address != target:
         console.print("\n=== Iniciando scan Nmap para IP resolvido ===", style="bold blue")
         nmap_ip_output = run_nmap_scan(ip_address)
@@ -766,6 +785,8 @@ def display_sequential_results(tool_results):
     Exibe no console os resultados de cada ferramenta e suas análises individuais.
     """
     console.print("\n=== RESULTADOS DOS SCANS SEQUENCIAIS ===", style="bold magenta")
+    console.print(f"IP do Pentest: {tool_results.get('pentest_ip', 'N/A')}")
+    console.print(f"IP do Alvo: {tool_results.get('target_ip', 'N/A')}")
     for tool in ["nmap", "nmap_ip", "nikto", "amass", "theharvester", "sublist3r", "dnsrecon", "sslyze"]:
         output = tool_results.get(f"{tool}_output", "")
         analysis = tool_results.get(f"{tool}_analysis", {})
@@ -789,6 +810,8 @@ def save_result(result_data):
     try:
         timestamp = datetime.now().isoformat()
         target = result_data.get("target", "N/A")
+        pentest_ip = result_data.get("pentest_ip", "N/A")
+        target_ip = result_data.get("target_ip", "N/A")
         combined_output = result_data.get("combined_output", "N/A")
         analyses = {
             tool: result_data.get(f"{tool}_analysis")
@@ -797,7 +820,7 @@ def save_result(result_data):
                 "theharvester", "sublist3r", "dnsrecon", "sslyze"
             ]
         }
-        save_to_json(timestamp, target, combined_output, analyses)
+        save_to_json(timestamp, target, pentest_ip, target_ip, combined_output, analyses)
         console.print(f"[+] Resultados gravados em '{RESULTS_FILE}'.", style="bold green")
     except Exception as e:
         console.print(f"[-] Erro ao salvar em JSON: {e}", style="bold red")
@@ -821,6 +844,11 @@ def save_result(result_data):
     </head>
     <body>
         <h1>Relatório de Scan para {target}</h1>
+        <h2>Informações</h2>
+        <ul>
+            <li><strong>IP do Pentest:</strong> {pentest_ip}</li>
+            <li><strong>IP do Alvo:</strong> {target_ip}</li>
+        </ul>
         <h2>Resultados Combinados</h2>
         <pre>{combined_output}</pre>
 
@@ -868,6 +896,8 @@ def view_results():
         for idx, record in enumerate(data, 1):
             console.print(f"\n----- Registro {idx} -----", style="bold blue")
             console.print(f"Data/Hora: {record.get('timestamp', 'N/A')}")
+            console.print(f"IP do Pentest: {record.get('pentest_ip', 'N/A')}")
+            console.print(f"IP do Alvo: {record.get('target_ip', 'N/A')}")
             console.print(f"Alvo: {record.get('target', 'N/A')}")
             console.print("[bold]Output combinado:[/bold]")
             console.print(record.get("combined_output", ""))


### PR DESCRIPTION
## Summary
- record the pentest and target IP in saved results
- show these IPs when displaying scan results
- include the IP information in generated HTML reports
- add helper to detect the local IP used for scanning

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68629d336bc4832abbdb495e89755b08