### PR TITLE
Add pentester and target IP info

### DIFF
--- a/report_menu.py
+++ b/report_menu.py
@@ -29,10 +29,10 @@ console = Console()
 
 
 def list_records():
-    """Retorna lista de (id, timestamp, ip_dominio_alvo) ordenados por id."""
+    """Retorna lista de (id, timestamp, client_ip, ip_dominio_alvo)."""
     with _CONN.cursor() as cur:
         cur.execute(
-            "SELECT id, timestamp, ip_dominio_alvo FROM resultscan ORDER BY id DESC"
+            "SELECT id, timestamp, client_ip, ip_dominio_alvo FROM resultscan ORDER BY id DESC"
         )
         return cur.fetchall()
 
@@ -70,7 +70,10 @@ def print_report(record):
     console.print("=" * 60)
     console.print("[bold blue]Relatório de Scan[/bold blue]")
     console.print(
-        f"ID: {record['id']} | Data: {record['timestamp']} | Alvo: {record['ip_dominio_alvo']}"
+        f"ID: {record['id']} | Data: {record['timestamp']}"
+    )
+    console.print(
+        f"IP do Pentester: {record['client_ip']} | Alvo: {record['ip_dominio_alvo']}"
     )
     console.print("=" * 60)
     console.print("[bold]Dados do Scan:[/bold]")
@@ -108,7 +111,8 @@ def save_html_report(record):
     <body>
         <header>
             <h1>{html_title}</h1>
-            <p>ID: {escape(str(record['id']))} | Data: {escape(str(record['timestamp']))} | Alvo: {escape(target)}</p>
+            <p>ID: {escape(str(record['id']))} | Data: {escape(str(record['timestamp']))}</p>
+            <p>IP do Pentester: {escape(record['client_ip'] or '-') } | Alvo: {escape(target)}</p>
         </header>
         <div class='section'>
             <h2>Dados do Scan</h2>
@@ -137,9 +141,10 @@ def main_menu():
         table = Table(title="Registros disponíveis")
         table.add_column("ID", justify="right")
         table.add_column("Data/Hora")
+        table.add_column("Pentester")
         table.add_column("Alvo")
-        for rid, ts, target in records:
-            table.add_row(str(rid), str(ts), target or "-")
+        for rid, ts, client_ip, target in records:
+            table.add_row(str(rid), str(ts), client_ip or "-", target or "-")
         console.print(table)
 
         choice = input("Digite o ID do registro (ou 's' para sair): ").strip()
@@ -163,7 +168,7 @@ def export_all_records():
     if not records:
         console.print("[*] Nenhum registro encontrado.", style="yellow")
         return
-    for rid, _, _ in records:
+    for rid, _, _, _ in records:
         record = get_record(rid)
         if record:
             save_html_report(record)


### PR DESCRIPTION
## Summary
- show IP do Pentester e IP do Alvo nos relatórios
- atualizar cabeçalho do relatório HTML
- exibir IP do pentester no menu de registros

## Testing
- `python -m py_compile report_menu.py`

------
https://chatgpt.com/codex/tasks/task_e_68629e888160832a937400f55d093a1a