### PR TITLE
Add model and host info to logs

### DIFF
--- a/API/llm_api_server.py
+++ b/API/llm_api_server.py
@@ -22,6 +22,7 @@ import zlib
 import requests
 import time
 import uuid
+import platform
 from collections import OrderedDict
 from dotenv import load_dotenv
 import argparse
@@ -37,6 +38,22 @@ except Exception:
 # Load environment variables from the project root
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 load_dotenv(os.path.join(BASE_DIR, ".env"))
+
+
+def _get_os_info() -> str:
+    """Retorna nome e versão do sistema operacional."""
+    try:
+        if hasattr(platform, "freedesktop_os_release"):
+            info = platform.freedesktop_os_release()
+            name = info.get("NAME", "").strip()
+            version = info.get("VERSION_ID", "").strip()
+            return f"{name} {version}".strip()
+    except Exception:
+        pass
+    return platform.platform()
+
+
+MACHINE_INFO = _get_os_info()
 
 from datetime import datetime
 from flask import Flask, request, jsonify
@@ -240,7 +257,9 @@ def init_db():
                     client_ip TEXT,
                     status TEXT,
                     processing_time REAL,
-                    data_size INTEGER
+                    data_size INTEGER,
+                    model_used TEXT,
+                    machine_info TEXT
                 )
                 """
             )
@@ -253,6 +272,8 @@ def init_db():
                     status TEXT,
                     processing_time REAL,
                     data_size INTEGER,
+                    model_used TEXT,
+                    machine_info TEXT,
                     ip_dominio_alvo TEXT,
                     scan_data TEXT,
                     analysis_result TEXT,
@@ -260,19 +281,31 @@ def init_db():
                 )
                 """
             )
+            cur.execute(
+                "ALTER TABLE requests_log ADD COLUMN IF NOT EXISTS model_used TEXT"
+            )
+            cur.execute(
+                "ALTER TABLE requests_log ADD COLUMN IF NOT EXISTS machine_info TEXT"
+            )
+            cur.execute(
+                "ALTER TABLE resultscan ADD COLUMN IF NOT EXISTS model_used TEXT"
+            )
+            cur.execute(
+                "ALTER TABLE resultscan ADD COLUMN IF NOT EXISTS machine_info TEXT"
+            )
         PG_CONN.commit()
     except Exception:
         logging.exception("Erro inicializando PostgreSQL")
 
-def log_request(client_ip, status, processing_time, data_size):
+def log_request(client_ip, status, processing_time, data_size, model_used, machine_info):
     """Grava metadados da requisição em requests_log."""
     try:
         with PG_CONN.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO requests_log
-                    (timestamp, client_ip, status, processing_time, data_size)
-                VALUES (%s, %s, %s, %s, %s)
+                    (timestamp, client_ip, status, processing_time, data_size, model_used, machine_info)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     datetime.utcnow(),
@@ -280,6 +313,8 @@ def log_request(client_ip, status, processing_time, data_size):
                     status,
                     processing_time,
                     data_size,
+                    model_used,
+                    machine_info,
                 ),
             )
         PG_CONN.commit()
@@ -287,7 +322,7 @@ def log_request(client_ip, status, processing_time, data_size):
         logging.exception("Erro registrando requisição")
 
 
-def save_log_to_db(client_ip, status, processing_time, data_size, ip_dominio_alvo, scan_data, result):
+def save_log_to_db(client_ip, status, processing_time, data_size, ip_dominio_alvo, scan_data, result, model_used, machine_info):
     """
     Persiste o log da análise na tabela resultscan.
     """
@@ -296,22 +331,27 @@ def save_log_to_db(client_ip, status, processing_time, data_size, ip_dominio_alv
         embedding = _embedder.encode(text_for_embedding)
         embedding_str = '[' + ','.join(f"{x:.6f}" for x in embedding.tolist()) + ']'
         with PG_CONN.cursor() as cur:
-            cur.execute("""
+            cur.execute(
+                """
                 INSERT INTO resultscan
-                  (timestamp, client_ip, status, processing_time, data_size, ip_dominio_alvo, scan_data, analysis_result, embedding)
+                  (timestamp, client_ip, status, processing_time, data_size, model_used, machine_info, ip_dominio_alvo, scan_data, analysis_result, embedding)
                 VALUES
-                  (%s, %s, %s, %s, %s, %s, %s, %s, %s)
-            """, (
-                datetime.utcnow(),
-                client_ip,
-                status,
-                processing_time,
-                data_size,
-                ip_dominio_alvo,
-                scan_data,
-                result,
-                embedding_str
-            ))
+                  (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+                (
+                    datetime.utcnow(),
+                    client_ip,
+                    status,
+                    processing_time,
+                    data_size,
+                    model_used,
+                    machine_info,
+                    ip_dominio_alvo,
+                    scan_data,
+                    result,
+                    embedding_str,
+                ),
+            )
         PG_CONN.commit()
     except Exception as e:
         logging.error(f"Erro ao gravar log no PostgreSQL: {e}")
@@ -479,6 +519,7 @@ def analyze():
     client_ip = request.remote_addr
     data_size = len(request.data)
     status = "failed"
+    model_used = HF_MODEL_NAME if LLM_BACKEND != "ollama" else SELECTED_MODEL
 
     if request.headers.get('X-API-Key') != API_KEY:
         console.print(f"[-] Tentativa de acesso não autorizado de {client_ip}", style="bold red")
@@ -530,10 +571,20 @@ def analyze():
         # Novo log da análise completa
         log_analysis(client_ip, status, processing_time, data_size, result)
         # gravação no banco relacional (agora síncrona)
-        save_log_to_db(client_ip, status, processing_time, data_size, ip_dominio_alvo, scan_data, result)
+        save_log_to_db(
+            client_ip,
+            status,
+            processing_time,
+            data_size,
+            ip_dominio_alvo,
+            scan_data,
+            result,
+            model_used,
+            MACHINE_INFO,
+        )
 
         if not callback_url:
-            log_request(client_ip, status, processing_time, data_size)
+            log_request(client_ip, status, processing_time, data_size, model_used, MACHINE_INFO)
             console.print("[+] Análise concluída e enviada ao cliente.", style="bold green")
             return jsonify({
                 "analysis": result,
@@ -555,7 +606,14 @@ def analyze():
                 console.print(f"[-] Erro no callback: {str(e)}", style="bold red")
 
         executor.submit(callback_task)
-        log_request(client_ip, "async_started", processing_time, data_size)
+        log_request(
+            client_ip,
+            "async_started",
+            processing_time,
+            data_size,
+            model_used,
+            MACHINE_INFO,
+        )
         console.print("[*] Análise em andamento (modo assíncrono).", style="bold yellow")
         return jsonify({
             "message": "Análise em andamento",
@@ -571,7 +629,7 @@ def analyze():
         error_msg = f"Erro interno: {str(e)}"
 
     processing_time = (datetime.now() - start_time).total_seconds()
-    log_request(client_ip, status, processing_time, data_size)
+    log_request(client_ip, status, processing_time, data_size, model_used, MACHINE_INFO)
     console.print(f"[-] Erro na requisição: {error_msg}", style="bold red")
     return jsonify({"error": error_msg}), 400
 

--- a/SQL/schema.sql
+++ b/SQL/schema.sql
@@ -9,7 +9,9 @@ CREATE TABLE IF NOT EXISTS requests_log (
     client_ip TEXT NOT NULL,
     status TEXT NOT NULL,
     processing_time REAL,
-    data_size INTEGER
+    data_size INTEGER,
+    model_used TEXT,
+    machine_info TEXT
 );
 
 CREATE TABLE IF NOT EXISTS resultscan (
@@ -19,6 +21,8 @@ CREATE TABLE IF NOT EXISTS resultscan (
     status TEXT NOT NULL,
     processing_time REAL,
     data_size INTEGER,
+    model_used TEXT,
+    machine_info TEXT,
     ip_dominio_alvo TEXT,
     scan_data TEXT,
     analysis_result TEXT,


### PR DESCRIPTION
## Summary
- extend DB schema with `model_used` and `machine_info`
- detect OS information at startup
- record selected model and machine info in requests and results tables

## Testing
- `python3 -m py_compile API/llm_api_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6862a07416f8832abdc7dcb9b337a734