### PR TITLE
Adiciona detalhes extras nos relatórios

### DIFF
--- a/report_menu.py
+++ b/report_menu.py
@@ -3,7 +3,9 @@
 
 O script se conecta ao banco PostgreSQL, lista os registros da tabela
 ``resultscan`` e permite que o usuário escolha qual deseja imprimir.
-Os relatórios incluem cabeçalho e rodapé para facilitar a leitura.
+Os relatórios incluem cabeçalho e rodapé para facilitar a leitura e
+agora exibem também o modelo utilizado e informações da máquina que
+processou a análise.
 """
 
 import os
@@ -43,6 +45,7 @@ def get_record(record_id):
         cur.execute(
             """
             SELECT id, timestamp, client_ip, status, processing_time, data_size,
+                   model_used, machine_info,
                    ip_dominio_alvo, scan_data, analysis_result
               FROM resultscan
              WHERE id = %s
@@ -59,9 +62,11 @@ def get_record(record_id):
         "status": row[3],
         "processing_time": row[4],
         "data_size": row[5],
-        "ip_dominio_alvo": row[6],
-        "scan_data": row[7],
-        "analysis_result": row[8],
+        "model_used": row[6],
+        "machine_info": row[7],
+        "ip_dominio_alvo": row[8],
+        "scan_data": row[9],
+        "analysis_result": row[10],
     }
 
 
@@ -75,6 +80,11 @@ def print_report(record):
     console.print(
         f"IP do Pentester: {record['client_ip']} | Alvo: {record['ip_dominio_alvo']}"
     )
+    console.print(
+        f"Status: {record['status']} | Tempo: {record['processing_time']}s | Dados: {record['data_size']} bytes"
+    )
+    console.print(f"Modelo: {record['model_used'] or '-'}")
+    console.print(f"Máquina: {record['machine_info'] or '-'}")
     console.print("=" * 60)
     console.print("[bold]Dados do Scan:[/bold]")
     console.print(record["scan_data"] or "-")
@@ -113,6 +123,8 @@ def save_html_report(record):
             <h1>{html_title}</h1>
             <p>ID: {escape(str(record['id']))} | Data: {escape(str(record['timestamp']))}</p>
             <p>IP do Pentester: {escape(record['client_ip'] or '-') } | Alvo: {escape(target)}</p>
+            <p>Status: {escape(record['status'] or '-')} | Tempo: {escape(str(record['processing_time']))}s | Dados: {escape(str(record['data_size']))} bytes</p>
+            <p>Modelo: {escape(record['model_used'] or '-')}</p>
         </header>
         <div class='section'>
             <h2>Dados do Scan</h2>
@@ -121,6 +133,10 @@ def save_html_report(record):
         <div class='section'>
             <h2>Análise da IA</h2>
             <pre>{escape(record['analysis_result'] or '-')}</pre>
+        </div>
+        <div class='section'>
+            <h2>Informações da Máquina</h2>
+            <pre>{escape(record['machine_info'] or '-')}</pre>
         </div>
         <footer>Relatório gerado em {datetime.now().isoformat()}</footer>
     </body>


### PR DESCRIPTION
## Summary
- incluir modelo utilizado e informações da máquina no relatório
- exibir status, tempo de processamento e tamanho dos dados
- atualizar layout do HTML para apresentar os novos campos

## Testing
- `python3 -m py_compile report_menu.py`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862a308010c832ab04e830c7d9a913d