### PR TITLE
Add consolidated report option

### DIFF
--- a/report_menu.py
+++ b/report_menu.py
@@ -39,6 +39,15 @@ def list_records():
         return cur.fetchall()
 
 
+def list_targets():
+    """Retorna lista de alvos distintos registrados."""
+    with _CONN.cursor() as cur:
+        cur.execute(
+            "SELECT DISTINCT ip_dominio_alvo FROM resultscan ORDER BY ip_dominio_alvo"
+        )
+        return [row[0] for row in cur.fetchall()]
+
+
 def get_record(record_id):
     """Obtém todos os campos relevantes de ``resultscan`` para o ``record_id``."""
     with _CONN.cursor() as cur:
@@ -68,6 +77,39 @@ def get_record(record_id):
         "scan_data": row[9],
         "analysis_result": row[10],
     }
+
+
+def get_records_by_target(target):
+    """Retorna todos os registros associados ao ``target``."""
+    with _CONN.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, timestamp, client_ip, status, processing_time, data_size,
+                   model_used, machine_info, scan_data, analysis_result
+              FROM resultscan
+             WHERE ip_dominio_alvo = %s
+             ORDER BY id
+            """,
+            (target,),
+        )
+        rows = cur.fetchall()
+    records = []
+    for row in rows:
+        records.append(
+            {
+                "id": row[0],
+                "timestamp": row[1],
+                "client_ip": row[2],
+                "status": row[3],
+                "processing_time": row[4],
+                "data_size": row[5],
+                "model_used": row[6],
+                "machine_info": row[7],
+                "scan_data": row[8],
+                "analysis_result": row[9],
+            }
+        )
+    return records
 
 
 def print_report(record):
@@ -146,6 +188,71 @@ def save_html_report(record):
     console.print(f"[green]Relatório HTML salvo em {filename}[/green]")
 
 
+def print_combined_report(records, target):
+    """Exibe no terminal todos os registros de um mesmo alvo."""
+    console.print("=" * 60)
+    console.print(f"[bold blue]Relatório Consolidado - {target}[/bold blue]")
+    for rec in records:
+        console.print("-" * 60)
+        console.print(f"[bold]Registro {rec['id']} | Data: {rec['timestamp']}[/bold]")
+        console.print(
+            f"IP do Pentester: {rec['client_ip']} | Status: {rec['status']} | Tempo: {rec['processing_time']}s | Dados: {rec['data_size']} bytes"
+        )
+        console.print(f"Modelo: {rec['model_used'] or '-'} | Máquina: {rec['machine_info'] or '-'}")
+        console.print("[bold]Dados do Scan:[/bold]")
+        console.print(rec["scan_data"] or "-")
+        console.print("\n[bold]Análise da IA:[/bold]")
+        console.print(rec["analysis_result"] or "-")
+    console.print("=" * 60)
+    console.print(f"Fim do Relatório Consolidado - gerado em {datetime.now().isoformat()}")
+    console.print("=" * 60)
+
+
+def save_html_combined_report(records, target):
+    """Salva todos os registros do alvo em um único arquivo HTML."""
+    sanitized_target = "".join(c if c.isalnum() or c in "-_." else "_" for c in target)
+    base_dir = os.path.join("reports", sanitized_target)
+    os.makedirs(base_dir, exist_ok=True)
+    filename = os.path.join(base_dir, f"relatorio_completo_{sanitized_target}.html")
+    html_title = escape(target)
+    sections = []
+    for rec in records:
+        sections.append(
+            f"""
+            <div class='section'>
+                <h2>Registro {escape(str(rec['id']))} - {escape(str(rec['timestamp']))}</h2>
+                <p>IP do Pentester: {escape(rec['client_ip'] or '-')} | Status: {escape(rec['status'] or '-')} | Tempo: {escape(str(rec['processing_time']))}s | Dados: {escape(str(rec['data_size']))} bytes</p>
+                <p>Modelo: {escape(rec['model_used'] or '-')} | Máquina: {escape(rec['machine_info'] or '-')}</p>
+                <h3>Dados do Scan</h3>
+                <pre>{escape(rec['scan_data'] or '-')}</pre>
+                <h3>Análise da IA</h3>
+                <pre>{escape(rec['analysis_result'] or '-')}</pre>
+            </div>
+            """
+        )
+    html = f"""<html>
+    <head>
+        <meta charset='utf-8'>
+        <title>{html_title}</title>
+        <style>
+            body {{ font-family: Arial, sans-serif; background-color: #f8f9fa; color: #333; }}
+            header {{ background-color: #1a237e; color: #fff; padding: 20px; text-align: center; }}
+            footer {{ background-color: #1a237e; color: #fff; text-align: center; padding: 10px; }}
+            .section {{ margin: 20px; padding: 15px; background-color: #fff; border: 1px solid #ddd; border-radius: 5px; }}
+            pre {{ white-space: pre-wrap; word-wrap: break-word; }}
+        </style>
+    </head>
+    <body>
+        <header><h1>{html_title}</h1></header>
+        {''.join(sections)}
+        <footer>Relatório gerado em {datetime.now().isoformat()}</footer>
+    </body>
+    </html>"""
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(html)
+    console.print(f"[green]Relatório consolidado salvo em {filename}[/green]")
+
+
 def main_menu():
     """Loop principal de seleção e impressão de relatórios."""
     while True:
@@ -163,9 +270,13 @@ def main_menu():
             table.add_row(str(rid), str(ts), client_ip or "-", target or "-")
         console.print(table)
 
-        choice = input("Digite o ID do registro (ou 's' para sair): ").strip()
+        console.print("[bold]Opções:[/bold] Digite o ID do registro, 'a' para listar por alvo ou 's' para sair.")
+        choice = input("Escolha: ").strip()
         if choice.lower() == "s":
             break
+        if choice.lower() == "a":
+            target_menu()
+            continue
         if not choice.isdigit():
             console.print("[!] Opção inválida.", style="red")
             continue
@@ -176,6 +287,33 @@ def main_menu():
             continue
         print_report(record)
         save_html_report(record)
+
+
+def target_menu():
+    """Permite ao usuário gerar relatório consolidado por alvo."""
+    targets = list_targets()
+    if not targets:
+        console.print("[*] Nenhum alvo encontrado.", style="yellow")
+        return
+    table = Table(title="Alvos disponíveis")
+    table.add_column("Opcão", justify="right")
+    table.add_column("Alvo")
+    for idx, t in enumerate(targets, 1):
+        table.add_row(str(idx), t or "-")
+    console.print(table)
+    choice = input("Escolha o número do alvo (ou 'v' para voltar): ").strip()
+    if choice.lower() == "v":
+        return
+    if not choice.isdigit() or not (1 <= int(choice) <= len(targets)):
+        console.print("[!] Opção inválida.", style="red")
+        return
+    target = targets[int(choice) - 1]
+    records = get_records_by_target(target)
+    if not records:
+        console.print("[*] Nenhum registro para este alvo.", style="yellow")
+        return
+    print_combined_report(records, target)
+    save_html_combined_report(records, target)
 
 
 def export_all_records():


### PR DESCRIPTION
## Summary
- gather targets from DB in report_menu
- retrieve all records for a target
- create functions to print and save consolidated HTML report
- extend main menu with option to select target for consolidated report

## Testing
- `pytest -q`
- `python -m py_compile report_menu.py`


------
https://chatgpt.com/codex/tasks/task_e_6862a9a379c4832abfb7a6ed44a2b466