### PR TITLE
Adjust progress monitor start

### DIFF
--- a/API/llm_api_server.py
+++ b/API/llm_api_server.py
@@ -783,10 +783,10 @@ if __name__ == "__main__":
             style="bold cyan",
         )
 
-    start_progress_monitor()
     local_app = create_app()
     try:
         console.print(f"[+] Iniciando servidor na porta {API_PORT}", style="bold green")
+        start_progress_monitor()
         local_app.run(host="0.0.0.0", port=API_PORT, threaded=True)
     except Exception as e:
         console.print(f"[-] Falha ao iniciar servidor: {str(e)}", style="bold red")


### PR DESCRIPTION
## Summary
- start progress monitor only after printing server start message

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862dafd0eac832a9a2bf9366b475336