### PR TITLE
Replace dnscan with dnsrecon

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Menu interativo para seleção das ferramentas e ordem de execução. Logs padro
 
 - **SO:** Debian 12 (ou derivados)
 - **Python:** 3.7+
-- **Ferramentas:** nmap, masscan, nikto, amass, dnsrecon, Sublist3r, Subfind3r, DataSploit, OSRFramework, Knockpy, Anubis, dnscan, Censys
+- **Ferramentas:** nmap, masscan, nikto, amass, dnsrecon, Sublist3r, Subfind3r, DataSploit, OSRFramework, Knockpy, Anubis, Censys
 - **Ollama:** Para executar modelos de IA localmente
 
 - **Hugging Face:** Para comunicar-se com modelos hospedados no hub (requer `huggingface-cli` para modelos privados)
@@ -102,7 +102,7 @@ sudo apt update && sudo apt install -y nmap masscan nikto amass dnsrecon
 #### Ferramentas adicionais via pip
 
 ```bash
-pip install datasploit osrframework Sublist3r subfind3r knockpy anubis dnscan censys-subdomain-finder slowloris pyslowloris pyloris
+pip install datasploit osrframework Sublist3r subfind3r knockpy anubis censys-subdomain-finder slowloris pyslowloris pyloris
 ```
 
 ### Banco de Dados
@@ -217,7 +217,7 @@ EMAIL_RECIPIENT=destino@email.com
 
 5. Siga o menu interativo para:
     - Scan de portas (Nmap/Masscan)
-    - Enumeração de subdomínios (Amass, Sublist3r, Subfind3r, Knockpy, Anubis, dnscan, Censys, dnsrecon)
+    - Enumeração de subdomínios (Amass, Sublist3r, Subfind3r, Knockpy, Anubis, Censys, dnsrecon)
    - Coleta de informações (DataSploit, OSRFramework, Nikto)
    - Análise com IA
    - Visualização de relatórios

--- a/SCAN/multi_scan_client.py
+++ b/SCAN/multi_scan_client.py
@@ -15,7 +15,7 @@ Funcionalidades:
  
 Requisitos:
     - Python 3.7+
-    - Ferramentas instaladas e acessíveis via linha de comando: Nmap, Nikto, Amass, Sublist3r, Subfind3r, DataSploit, OSRFramework, Knockpy, Anubis, dnscan, Censys, dnsrecon, masscan e SSLyze.
+    - Ferramentas instaladas e acessíveis via linha de comando: Nmap, Nikto, Amass, Sublist3r, Subfind3r, DataSploit, OSRFramework, Knockpy, Anubis, Censys, dnsrecon, masscan e SSLyze.
     - API do LLMA (via Ollama) rodando localmente.
     - Bibliotecas: requests (pip install requests) e rich (pip install rich).
     - Biblioteca para banco de dados SQLite (nativa no Python) ou outro DB à sua escolha.
@@ -63,7 +63,6 @@ from utils import (
     run_osrframework,
     run_knockpy,
     run_anubis,
-    run_dnscan,
     run_censys_subdomain,
     run_wfuzz,
     run_ffuf,
@@ -291,11 +290,11 @@ def run_scans_sequential(target):
     tool_results["anubis_output"] = anubis_output
     tool_results["anubis_analysis"] = send_to_deepseek(anubis_output, target)
 
-    # 12) dnscan
-    console.print("\n=== Iniciando dnscan ===", style="bold blue")
-    dnscan_output = run_dnscan(target)
-    tool_results["dnscan_output"] = dnscan_output
-    tool_results["dnscan_analysis"] = send_to_deepseek(dnscan_output, target)
+    # 12) dnsrecon
+    console.print("\n=== Iniciando dnsrecon ===", style="bold blue")
+    dnsrecon_output = run_dnsrecon(target)
+    tool_results["dnsrecon_output"] = dnsrecon_output
+    tool_results["dnsrecon_analysis"] = send_to_deepseek(dnsrecon_output, target)
 
     # 13) Censys
     console.print("\n=== Iniciando Censys ===", style="bold blue")
@@ -351,13 +350,7 @@ def run_scans_sequential(target):
     tool_results["goloris_output"] = goloris_output
     tool_results["goloris_analysis"] = send_to_deepseek(goloris_output, target)
 
-    # 22) dnsrecon
-    console.print("\n=== Iniciando scan dnsrecon ===", style="bold blue")
-    dnsrecon_output = run_dnsrecon(target)
-    tool_results["dnsrecon_output"] = dnsrecon_output
-    tool_results["dnsrecon_analysis"] = send_to_deepseek(dnsrecon_output, target)
-    
-    # 23) SSLyze
+    # 22) SSLyze
     console.print("\n=== Iniciando scan SSLyze ===", style="bold blue")
     sslyze_output = run_sslyze_scan(target)
     tool_results["sslyze_output"] = sslyze_output
@@ -375,7 +368,6 @@ def run_scans_sequential(target):
         f"=== RESULTADOS Subfind3r ===\n{tool_results.get('subfind3r_output', '')}\n\n"
         f"=== RESULTADOS Knockpy ===\n{tool_results.get('knockpy_output', '')}\n\n"
         f"=== RESULTADOS Anubis ===\n{tool_results.get('anubis_output', '')}\n\n"
-        f"=== RESULTADOS dnscan ===\n{tool_results.get('dnscan_output', '')}\n\n"
         f"=== RESULTADOS Censys ===\n{tool_results.get('censys_output', '')}\n\n"
         f"=== RESULTADOS Wfuzz ===\n{tool_results.get('wfuzz_output', '')}\n\n"
         f"=== RESULTADOS ffuf ===\n{tool_results.get('ffuf_output', '')}\n\n"
@@ -403,7 +395,7 @@ def display_sequential_results(tool_results):
         "nmap", "nmap_ip", "ipinfo", "nikto", "amass",
         "datasploit", "osrframework",
         "sublist3r", "subfind3r", "knockpy", "anubis",
-        "dnscan", "censys", "wfuzz", "ffuf", "gobuster",
+        "censys", "wfuzz", "ffuf", "gobuster",
         "slowloris", "pyslowloris", "pyloris", "slowhttptest", "goloris",
         "dnsrecon", "sslyze"
     ]:
@@ -436,7 +428,7 @@ def save_result(result_data):
                 "nmap", "nmap_ip", "ipinfo", "nikto", "amass",
                 "datasploit", "osrframework",
                 "sublist3r", "subfind3r", "knockpy", "anubis",
-                "dnscan", "censys", "wfuzz", "ffuf", "gobuster",
+                "censys", "wfuzz", "ffuf", "gobuster",
                 "slowloris", "pyslowloris", "pyloris", "slowhttptest", "goloris",
                 "dnsrecon", "sslyze"
             ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ Sublist3r
 subfind3r
 knockpy
 anubis
-dnscan
 censys-subdomain-finder
 slowloris
 pyslowloris

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -12,7 +12,6 @@ from .scanner_tools import (
     run_osrframework,
     run_knockpy,
     run_anubis,
-    run_dnscan,
     run_censys_subdomain,
     run_wfuzz,
     run_ffuf,
@@ -34,7 +33,7 @@ __all__ = [
     'normalize_target', 'log_message', 'is_ip', 'run_nmap_scan', 'get_server_ip',
     'run_nikto_scan', 'run_amass_enum', 'run_sublist3r', 'run_subfind3r',
     'run_datasploit', 'run_osrframework', 'run_knockpy',
-    'run_anubis', 'run_dnscan', 'run_censys_subdomain', 'run_wfuzz', 'run_ffuf',
+    'run_anubis', 'run_censys_subdomain', 'run_wfuzz', 'run_ffuf',
     'run_gobuster', 'run_slowloris', 'run_pyslowloris', 'run_pyloris',
     'run_slowhttptest', 'run_goloris', 'run_dnsrecon', 'run_masscan',
     'ping_scan', 'run_sslyze_scan', 'fetch_ipinfo', 'setup_signal_protection'

--- a/utils/scanner_tools.py
+++ b/utils/scanner_tools.py
@@ -200,16 +200,6 @@ def run_anubis(target: str) -> str:
         return f"Erro no Anubis: {e.stderr}"
 
 
-def run_dnscan(target: str) -> str:
-    normalized = normalize_target(target)
-    log_message(f"Iniciando dnscan para {normalized}")
-    cmd = ["dnscan","-d",normalized,"-w","/usr/share/wordlists/dns.txt","-o","dnscan_output","-r"]
-    try:
-        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
-        return proc.stdout
-    except subprocess.CalledProcessError as e:
-        return f"Erro no dnscan: {e.stderr}"
-
 
 def run_censys_subdomain(target: str) -> str:
     normalized = normalize_target(target)


### PR DESCRIPTION
## Summary
- remove dnscan dependency
- use dnsrecon instead of dnscan in scanning workflow
- clean up utils exports
- update documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6870198e93d4832a8f6aac68f662991a