### PR TITLE
Remove censys-subdomain-finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Menu interativo para seleção das ferramentas e ordem de execução. Logs padro
 
 - **SO:** Debian 12 (ou derivados)
 - **Python:** 3.7+
-- **Ferramentas:** nmap, masscan, nikto, amass, dnsrecon, Sublist3r, Subfind3r, DataSploit, OSRFramework, Knockpy, Anubis, Censys
+- **Ferramentas:** nmap, masscan, nikto, amass, dnsrecon, Sublist3r, Subfind3r, DataSploit, OSRFramework, Knockpy, Anubis
 - **Ollama:** Para executar modelos de IA localmente
 
 - **Hugging Face:** Para comunicar-se com modelos hospedados no hub (requer `huggingface-cli` para modelos privados)
@@ -102,7 +102,7 @@ sudo apt update && sudo apt install -y nmap masscan nikto amass dnsrecon
 #### Ferramentas adicionais via pip
 
 ```bash
-pip install datasploit osrframework Sublist3r subfind3r knockpy anubis censys-subdomain-finder slowloris pyslowloris pyloris
+pip install datasploit osrframework Sublist3r subfind3r knockpy anubis slowloris pyslowloris pyloris
 ```
 
 ### Banco de Dados
@@ -217,7 +217,7 @@ EMAIL_RECIPIENT=destino@email.com
 
 5. Siga o menu interativo para:
     - Scan de portas (Nmap/Masscan)
-    - Enumeração de subdomínios (Amass, Sublist3r, Subfind3r, Knockpy, Anubis, Censys, dnsrecon)
+    - Enumeração de subdomínios (Amass, Sublist3r, Subfind3r, Knockpy, Anubis, dnsrecon)
    - Coleta de informações (DataSploit, OSRFramework, Nikto)
    - Análise com IA
    - Visualização de relatórios

--- a/SCAN/multi_scan_client.py
+++ b/SCAN/multi_scan_client.py
@@ -15,7 +15,7 @@ Funcionalidades:
  
 Requisitos:
     - Python 3.7+
-    - Ferramentas instaladas e acessíveis via linha de comando: Nmap, Nikto, Amass, Sublist3r, Subfind3r, DataSploit, OSRFramework, Knockpy, Anubis, Censys, dnsrecon, masscan e SSLyze.
+    - Ferramentas instaladas e acessíveis via linha de comando: Nmap, Nikto, Amass, Sublist3r, Subfind3r, DataSploit, OSRFramework, Knockpy, Anubis, dnsrecon, masscan e SSLyze.
     - API do LLMA (via Ollama) rodando localmente.
     - Bibliotecas: requests (pip install requests) e rich (pip install rich).
     - Biblioteca para banco de dados SQLite (nativa no Python) ou outro DB à sua escolha.
@@ -63,7 +63,6 @@ from utils import (
     run_osrframework,
     run_knockpy,
     run_anubis,
-    run_censys_subdomain,
     run_wfuzz,
     run_ffuf,
     run_gobuster,
@@ -296,61 +295,55 @@ def run_scans_sequential(target):
     tool_results["dnsrecon_output"] = dnsrecon_output
     tool_results["dnsrecon_analysis"] = send_to_deepseek(dnsrecon_output, target)
 
-    # 13) Censys
-    console.print("\n=== Iniciando Censys ===", style="bold blue")
-    censys_output = run_censys_subdomain(target)
-    tool_results["censys_output"] = censys_output
-    tool_results["censys_analysis"] = send_to_deepseek(censys_output, target)
-
-    # 14) Wfuzz
+    # 13) Wfuzz
     console.print("\n=== Iniciando Wfuzz ===", style="bold blue")
     wfuzz_output = run_wfuzz(target)
     tool_results["wfuzz_output"] = wfuzz_output
     tool_results["wfuzz_analysis"] = send_to_deepseek(wfuzz_output, target)
 
-    # 15) ffuf
+    # 14) ffuf
     console.print("\n=== Iniciando ffuf ===", style="bold blue")
     ffuf_output = run_ffuf(target)
     tool_results["ffuf_output"] = ffuf_output
     tool_results["ffuf_analysis"] = send_to_deepseek(ffuf_output, target)
 
-    # 16) Gobuster
+    # 15) Gobuster
     console.print("\n=== Iniciando Gobuster ===", style="bold blue")
     gobuster_output = run_gobuster(target)
     tool_results["gobuster_output"] = gobuster_output
     tool_results["gobuster_analysis"] = send_to_deepseek(gobuster_output, target)
 
-    # 17) Slowloris
+    # 16) Slowloris
     console.print("\n=== Iniciando Slowloris ===", style="bold blue")
     slowloris_output = run_slowloris(target)
     tool_results["slowloris_output"] = slowloris_output
     tool_results["slowloris_analysis"] = send_to_deepseek(slowloris_output, target)
 
-    # 18) PySlowLoris
+    # 17) PySlowLoris
     console.print("\n=== Iniciando PySlowLoris ===", style="bold blue")
     pyslowloris_output = run_pyslowloris(target)
     tool_results["pyslowloris_output"] = pyslowloris_output
     tool_results["pyslowloris_analysis"] = send_to_deepseek(pyslowloris_output, target)
 
-    # 19) PyLoris
+    # 18) PyLoris
     console.print("\n=== Iniciando PyLoris ===", style="bold blue")
     pyloris_output = run_pyloris(target)
     tool_results["pyloris_output"] = pyloris_output
     tool_results["pyloris_analysis"] = send_to_deepseek(pyloris_output, target)
 
-    # 20) SlowHTTPTest
+    # 19) SlowHTTPTest
     console.print("\n=== Iniciando SlowHTTPTest ===", style="bold blue")
     slowhttptest_output = run_slowhttptest(target)
     tool_results["slowhttptest_output"] = slowhttptest_output
     tool_results["slowhttptest_analysis"] = send_to_deepseek(slowhttptest_output, target)
 
-    # 21) GOLoris
+    # 20) GOLoris
     console.print("\n=== Iniciando GOLoris ===", style="bold blue")
     goloris_output = run_goloris(target)
     tool_results["goloris_output"] = goloris_output
     tool_results["goloris_analysis"] = send_to_deepseek(goloris_output, target)
 
-    # 22) SSLyze
+    # 21) SSLyze
     console.print("\n=== Iniciando scan SSLyze ===", style="bold blue")
     sslyze_output = run_sslyze_scan(target)
     tool_results["sslyze_output"] = sslyze_output
@@ -368,7 +361,6 @@ def run_scans_sequential(target):
         f"=== RESULTADOS Subfind3r ===\n{tool_results.get('subfind3r_output', '')}\n\n"
         f"=== RESULTADOS Knockpy ===\n{tool_results.get('knockpy_output', '')}\n\n"
         f"=== RESULTADOS Anubis ===\n{tool_results.get('anubis_output', '')}\n\n"
-        f"=== RESULTADOS Censys ===\n{tool_results.get('censys_output', '')}\n\n"
         f"=== RESULTADOS Wfuzz ===\n{tool_results.get('wfuzz_output', '')}\n\n"
         f"=== RESULTADOS ffuf ===\n{tool_results.get('ffuf_output', '')}\n\n"
         f"=== RESULTADOS Gobuster ===\n{tool_results.get('gobuster_output', '')}\n\n"
@@ -395,7 +387,7 @@ def display_sequential_results(tool_results):
         "nmap", "nmap_ip", "ipinfo", "nikto", "amass",
         "datasploit", "osrframework",
         "sublist3r", "subfind3r", "knockpy", "anubis",
-        "censys", "wfuzz", "ffuf", "gobuster",
+        "wfuzz", "ffuf", "gobuster",
         "slowloris", "pyslowloris", "pyloris", "slowhttptest", "goloris",
         "dnsrecon", "sslyze"
     ]:
@@ -428,7 +420,7 @@ def save_result(result_data):
                 "nmap", "nmap_ip", "ipinfo", "nikto", "amass",
                 "datasploit", "osrframework",
                 "sublist3r", "subfind3r", "knockpy", "anubis",
-                "censys", "wfuzz", "ffuf", "gobuster",
+                "wfuzz", "ffuf", "gobuster",
                 "slowloris", "pyslowloris", "pyloris", "slowhttptest", "goloris",
                 "dnsrecon", "sslyze"
             ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ Sublist3r
 subfind3r
 knockpy
 anubis
-censys-subdomain-finder
 slowloris
 pyslowloris
 pyloris

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -12,7 +12,6 @@ from .scanner_tools import (
     run_osrframework,
     run_knockpy,
     run_anubis,
-    run_censys_subdomain,
     run_wfuzz,
     run_ffuf,
     run_gobuster,
@@ -33,7 +32,7 @@ __all__ = [
     'normalize_target', 'log_message', 'is_ip', 'run_nmap_scan', 'get_server_ip',
     'run_nikto_scan', 'run_amass_enum', 'run_sublist3r', 'run_subfind3r',
     'run_datasploit', 'run_osrframework', 'run_knockpy',
-    'run_anubis', 'run_censys_subdomain', 'run_wfuzz', 'run_ffuf',
+    'run_anubis', 'run_wfuzz', 'run_ffuf',
     'run_gobuster', 'run_slowloris', 'run_pyslowloris', 'run_pyloris',
     'run_slowhttptest', 'run_goloris', 'run_dnsrecon', 'run_masscan',
     'ping_scan', 'run_sslyze_scan', 'fetch_ipinfo', 'setup_signal_protection'

--- a/utils/scanner_tools.py
+++ b/utils/scanner_tools.py
@@ -201,16 +201,6 @@ def run_anubis(target: str) -> str:
 
 
 
-def run_censys_subdomain(target: str) -> str:
-    normalized = normalize_target(target)
-    log_message(f"Iniciando Censys para {normalized}")
-    cmd = ["censys-subdomain-finder","-d",normalized,"-o","censys_output.txt"]
-    try:
-        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
-        return proc.stdout
-    except subprocess.CalledProcessError as e:
-        return f"Erro no Censys: {e.stderr}"
-
 
 def run_wfuzz(target: str) -> str:
     normalized = normalize_target(target)


### PR DESCRIPTION
## Summary
- drop censys-subdomain-finder dependency
- update scanner utilities and exports
- eliminate Censys usage from multi_scan_client
- clean README references to Censys

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68701d844e8c832a9a6e25ae3d15cba1