### PR TITLE
Store IPinfo data and highlight in reports

### DIFF
--- a/API/llm_api_server.py
+++ b/API/llm_api_server.py
@@ -322,7 +322,7 @@ def log_request(client_ip, status, processing_time, data_size, model_used, machi
         logging.exception("Erro registrando requisição")
 
 
-def save_log_to_db(client_ip, status, processing_time, data_size, ip_dominio_alvo, scan_data, result, model_used, machine_info):
+def save_log_to_db(client_ip, status, processing_time, data_size, ip_dominio_alvo, scan_data, result, model_used, machine_info, ipinfo_data=None):
     """
     Persiste o log da análise na tabela resultscan.
     """
@@ -334,9 +334,9 @@ def save_log_to_db(client_ip, status, processing_time, data_size, ip_dominio_alv
             cur.execute(
                 """
                 INSERT INTO resultscan
-                  (timestamp, client_ip, status, processing_time, data_size, model_used, machine_info, ip_dominio_alvo, scan_data, analysis_result, embedding)
+                  (timestamp, client_ip, status, processing_time, data_size, model_used, machine_info, ip_dominio_alvo, scan_data, analysis_result, ipinfo_data, embedding)
                 VALUES
-                  (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                  (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
                 (
                     datetime.utcnow(),
@@ -349,6 +349,7 @@ def save_log_to_db(client_ip, status, processing_time, data_size, ip_dominio_alv
                     ip_dominio_alvo,
                     scan_data,
                     result,
+                    ipinfo_data,
                     embedding_str,
                 ),
             )
@@ -501,6 +502,7 @@ if USE_PYDANTIC:
         scan_data: str
         context: str
         ip_dominio_alvo: str | None = None
+        ipinfo_data: str | None = None
         callback_url: str | None = None
 
 # ---------------------- ROTAS ----------------------
@@ -520,6 +522,7 @@ def analyze():
     data_size = len(request.data)
     status = "failed"
     model_used = HF_MODEL_NAME if LLM_BACKEND != "ollama" else SELECTED_MODEL
+    ipinfo_data = None
 
     if request.headers.get('X-API-Key') != API_KEY:
         console.print(f"[-] Tentativa de acesso não autorizado de {client_ip}", style="bold red")
@@ -538,6 +541,7 @@ def analyze():
             scan_data = payload.scan_data
             context = payload.context
             ip_dominio_alvo = payload.ip_dominio_alvo
+            ipinfo_data = payload.ipinfo_data
             callback_url = payload.callback_url
         else:
             data = json.loads(json_data)
@@ -546,6 +550,7 @@ def analyze():
             scan_data = data['scan_data']
             context = data['context']
             ip_dominio_alvo = data.get('ip_dominio_alvo')
+            ipinfo_data = data.get('ipinfo_data')
             callback_url = data.get('callback_url')
 
         console.print("[*] Processando análise...", style="bold yellow")
@@ -581,6 +586,7 @@ def analyze():
             result,
             model_used,
             MACHINE_INFO,
+            ipinfo_data,
         )
 
         if not callback_url:

--- a/SCAN/multi_scan_client.py
+++ b/SCAN/multi_scan_client.py
@@ -144,7 +144,7 @@ def save_to_json(timestamp, target, combined_output, analyses):
     with open(RESULTS_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=4)
 
-def send_to_deepseek(scan_data, ip_dominio_alvo=None):
+def send_to_deepseek(scan_data, ip_dominio_alvo=None, ipinfo_data=None):
     """
     Envia os dados para a API do LLMA e aguarda a resposta.
 
@@ -157,6 +157,8 @@ def send_to_deepseek(scan_data, ip_dominio_alvo=None):
     }
     if ip_dominio_alvo:
         payload["ip_dominio_alvo"] = ip_dominio_alvo
+    if ipinfo_data:
+        payload["ipinfo_data"] = ipinfo_data
     headers = {"X-API-Key": API_KEY}
     try:
         console.print(
@@ -236,7 +238,7 @@ def run_scans_sequential(target):
     ipinfo_data = fetch_ipinfo(ip_for_info)
     ipinfo_output = json.dumps(ipinfo_data, ensure_ascii=False, indent=2)
     tool_results["ipinfo_output"] = ipinfo_output
-    tool_results["ipinfo_analysis"] = send_to_deepseek(ipinfo_output, ip_for_info)
+    tool_results["ipinfo_analysis"] = send_to_deepseek(ipinfo_output, ip_for_info, ipinfo_output)
     # 4) Nikto
     console.print("\n=== Iniciando scan Nikto ===", style="bold blue")
     nikto_output = run_nikto_scan(target)

--- a/SQL/schema.sql
+++ b/SQL/schema.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS resultscan (
     ip_dominio_alvo TEXT,
     scan_data TEXT,
     analysis_result TEXT,
+    ipinfo_data TEXT,
     embedding vector(768)
 );
 

--- a/report_menu.py
+++ b/report_menu.py
@@ -55,7 +55,7 @@ def get_record(record_id):
             """
             SELECT id, timestamp, client_ip, status, processing_time, data_size,
                    model_used, machine_info,
-                   ip_dominio_alvo, scan_data, analysis_result
+                   ip_dominio_alvo, scan_data, analysis_result, ipinfo_data
               FROM resultscan
              WHERE id = %s
             """,
@@ -76,6 +76,7 @@ def get_record(record_id):
         "ip_dominio_alvo": row[8],
         "scan_data": row[9],
         "analysis_result": row[10],
+        "ipinfo_data": row[11],
     }
 
 
@@ -85,7 +86,7 @@ def get_records_by_target(target):
         cur.execute(
             """
             SELECT id, timestamp, client_ip, status, processing_time, data_size,
-                   model_used, machine_info, scan_data, analysis_result
+                   model_used, machine_info, scan_data, analysis_result, ipinfo_data
               FROM resultscan
              WHERE ip_dominio_alvo = %s
              ORDER BY id
@@ -107,6 +108,7 @@ def get_records_by_target(target):
                 "machine_info": row[7],
                 "scan_data": row[8],
                 "analysis_result": row[9],
+                "ipinfo_data": row[10],
             }
         )
     return records
@@ -127,6 +129,9 @@ def print_report(record):
     )
     console.print(f"Modelo: {record['model_used'] or '-'}")
     console.print(f"Máquina: {record['machine_info'] or '-'}")
+    if record.get('ipinfo_data'):
+        console.print("[bold]Informações IPinfo:[/bold]")
+        console.print(record['ipinfo_data'])
     console.print("=" * 60)
     console.print("[bold]Dados do Scan:[/bold]")
     console.print(record["scan_data"] or "-")
@@ -180,6 +185,7 @@ def save_html_report(record):
             <h2>Informações da Máquina</h2>
             <pre>{escape(record['machine_info'] or '-')}</pre>
         </div>
+        {f"<div class='section'><h2>Dados do IPinfo</h2><pre>{escape(record['ipinfo_data'])}</pre></div>" if record.get('ipinfo_data') else ''}
         <footer>Relatório gerado em {datetime.now().isoformat()}</footer>
     </body>
     </html>"""
@@ -199,6 +205,9 @@ def print_combined_report(records, target):
             f"IP do Pentester: {rec['client_ip']} | Status: {rec['status']} | Tempo: {rec['processing_time']}s | Dados: {rec['data_size']} bytes"
         )
         console.print(f"Modelo: {rec['model_used'] or '-'} | Máquina: {rec['machine_info'] or '-'}")
+        if rec.get('ipinfo_data'):
+            console.print('[bold]Dados do IPinfo:[/bold]')
+            console.print(rec['ipinfo_data'])
         console.print("[bold]Dados do Scan:[/bold]")
         console.print(rec["scan_data"] or "-")
         console.print("\n[bold]Análise da IA:[/bold]")
@@ -223,6 +232,7 @@ def save_html_combined_report(records, target):
                 <h2>Registro {escape(str(rec['id']))} - {escape(str(rec['timestamp']))}</h2>
                 <p>IP do Pentester: {escape(rec['client_ip'] or '-')} | Status: {escape(rec['status'] or '-')} | Tempo: {escape(str(rec['processing_time']))}s | Dados: {escape(str(rec['data_size']))} bytes</p>
                 <p>Modelo: {escape(rec['model_used'] or '-')} | Máquina: {escape(rec['machine_info'] or '-')}</p>
+                {f"<h3>Dados do IPinfo</h3><pre>{escape(rec['ipinfo_data'])}</pre>" if rec.get('ipinfo_data') else ''}
                 <h3>Dados do Scan</h3>
                 <pre>{escape(rec['scan_data'] or '-')}</pre>
                 <h3>Análise da IA</h3>


### PR DESCRIPTION
## Summary
- capture IPinfo results in the database with new `ipinfo_data` column
- accept and store new field in API server
- send IPinfo data from scan client
- display IPinfo details in HTML/terminal reports

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687025398084832aa2ab72806592e51f