### PR TITLE
Fix web panel launch command

### DIFF
--- a/SCAN/multi_scan_client.py
+++ b/SCAN/multi_scan_client.py
@@ -526,8 +526,13 @@ def toggle_web_panel():
         WEB_PANEL_PROCESS = None
         console.print("Painel web desativado.", style="bold green")
     else:
-        panel_path = os.path.join(BASE_DIR, 'web_panel', 'web_panel.py')
-        WEB_PANEL_PROCESS = subprocess.Popen([sys.executable, panel_path])
+        # Use -m to run the web panel as a module to avoid import issues
+        panel_module = 'web_panel.web_panel'
+        WEB_PANEL_PROCESS = subprocess.Popen([
+            sys.executable,
+            '-m',
+            panel_module,
+        ])
         console.print("Painel web disponível em http://localhost:8000", style="bold green")
 
 # ==================== MENU PRINCIPAL ====================


### PR DESCRIPTION
## Summary
- update web panel spawning logic to use `python -m` for proper module imports

## Testing
- `python -m SCAN.multi_scan_client` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6870628142dc832a9004805ddc1e92cb