### PR TITLE
Centralized logging and hide flask output

### DIFF
--- a/API/llm_api_server.py
+++ b/API/llm_api_server.py
@@ -24,6 +24,7 @@ import time
 import uuid
 import platform
 from collections import OrderedDict
+from utils.logger import setup_logging
 from dotenv import load_dotenv
 import argparse
 
@@ -147,19 +148,10 @@ except ImportError:
 
 # ---------------------- CONFIGURAÇÕES ----------------------
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-LOG_FOLDER = os.path.join(BASE_DIR, "logs")
-LOG_FILE = os.path.join(LOG_FOLDER, "api_server.log")
-
+LOG_FOLDER = os.path.join(os.path.dirname(BASE_DIR), "logs_eventos")
 os.makedirs(LOG_FOLDER, exist_ok=True)
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[
-        logging.FileHandler(LOG_FILE),
-        logging.StreamHandler(sys.stdout)
-    ]
-)
+logger = setup_logging("api_server")
 
 API_PORT = int(os.getenv("API_PORT", 5000))
 API_KEY = os.environ.get("PENTEST_API_KEY")
@@ -238,7 +230,7 @@ def log_analysis(client_ip, status, processing_time, data_size, result):
         with open(log_file_path, "a", encoding="utf-8") as log_file:
             log_file.write(log_line + "\n")
     except Exception as e:
-        logging.error(f"Erro ao escrever no log de análise: {str(e)}")
+        logger.error(f"Erro ao escrever no log de análise: {str(e)}")
         console.print(f"[-] Falha no log da análise: {str(e)}", style="bold red")
 
 # ---------------------- BANCO DE DADOS ----------------------
@@ -295,7 +287,7 @@ def init_db():
             )
         PG_CONN.commit()
     except Exception:
-        logging.exception("Erro inicializando PostgreSQL")
+        logger.exception("Erro inicializando PostgreSQL")
 
 def log_request(client_ip, status, processing_time, data_size, model_used, machine_info):
     """Grava metadados da requisição em requests_log."""
@@ -319,7 +311,7 @@ def log_request(client_ip, status, processing_time, data_size, model_used, machi
             )
         PG_CONN.commit()
     except Exception:
-        logging.exception("Erro registrando requisição")
+        logger.exception("Erro registrando requisição")
 
 
 def save_log_to_db(client_ip, status, processing_time, data_size, ip_dominio_alvo, scan_data, result, model_used, machine_info, ipinfo_data=None):
@@ -355,7 +347,7 @@ def save_log_to_db(client_ip, status, processing_time, data_size, ip_dominio_alv
             )
         PG_CONN.commit()
     except Exception as e:
-        logging.error(f"Erro ao gravar log no PostgreSQL: {e}")
+        logger.error(f"Erro ao gravar log no PostgreSQL: {e}")
 
 # ---------------------- FUNÇÕES DE ANÁLISE ----------------------
 def test_model():
@@ -377,14 +369,14 @@ def test_model():
             )
             return "error" not in test_result.stderr.lower()
         except Exception as e:
-            logging.error(f"Falha no teste do Ollama: {str(e)}")
+            logger.error(f"Falha no teste do Ollama: {str(e)}")
             return False
     else:
         try:
             HF_PIPELINE("Teste de conexão")
             return True
         except Exception as e:
-            logging.error(f"Falha no teste do modelo Hugging Face: {str(e)}")
+            logger.error(f"Falha no teste do modelo Hugging Face: {str(e)}")
             return False
 
 def clean_analysis_result(text):
@@ -415,7 +407,7 @@ def profile_if_enabled(func):
             pr.disable()
             s = io.StringIO()
             pstats.Stats(pr, stream=s).sort_stats("cumtime").print_stats(20)
-            logging.info("Profiling for %s:\n%s", func.__name__, s.getvalue())
+            logger.info("Profiling for %s:\n%s", func.__name__, s.getvalue())
             return result
         return func(*args, **kwargs)
     return wrapper
@@ -478,7 +470,7 @@ def process_analysis(scan_data, context):
         return "Erro: Tempo excedido na análise"
     except Exception as e:
         console.print(f"[-] Erro no processamento: {str(e)}", style="bold red")
-        logging.exception("Erro no processamento da análise")
+        logger.exception("Erro no processamento da análise")
         return f"Erro na análise: {str(e)}"
 
 # ---------------------- CRIAÇÃO DO FLASK ----------------------
@@ -608,7 +600,7 @@ def analyze():
                 )
                 console.print("[+] Resultados enviados com sucesso.", style="bold green")
             except Exception as e:
-                logging.exception("Erro no callback")
+                logger.exception("Erro no callback")
                 console.print(f"[-] Erro no callback: {str(e)}", style="bold red")
 
         executor.submit(callback_task)
@@ -631,7 +623,7 @@ def analyze():
     except json.JSONDecodeError:
         error_msg = "Formato JSON inválido"
     except Exception as e:
-        logging.exception("Erro geral no endpoint /analyze")
+        logger.exception("Erro geral no endpoint /analyze")
         error_msg = f"Erro interno: {str(e)}"
 
     processing_time = (datetime.now() - start_time).total_seconds()
@@ -655,12 +647,12 @@ def not_found(e):
 
 @app.errorhandler(400)
 def bad_request(e):
-    logging.error("Bad Request: " + str(e))
+    logger.error("Bad Request: " + str(e))
     return jsonify({"error": "Requisição malformada", "details": str(e)}), 400
 
 @app.errorhandler(500)
 def internal_error(e):
-    logging.exception("Erro interno (500)")
+    logger.exception("Erro interno (500)")
     return jsonify({"error": "Erro interno do servidor"}), 500
 
 # ---------------------- CRIAÇÃO FINAL DA APP ----------------------

--- a/SCAN/multi_scan_client.py
+++ b/SCAN/multi_scan_client.py
@@ -48,6 +48,7 @@ load_dotenv(os.path.join(BASE_DIR, ".env"))
 from datetime import datetime
 import requests
 from rich.console import Console
+from utils.logger import setup_logging
 from utils import (
     setup_signal_protection,
     fetch_ipinfo,
@@ -112,8 +113,10 @@ selected_context = CONTEXT_MAP[selected_context_name]
 RESULTS_FILE = "results.json"
 NETWORK_DEVICES_FILE = "network_devices.txt"
 WEB_PANEL_PROCESS = None
+WEB_PANEL_LOG = None
 
 console = Console()
+logger = setup_logging("client")
 setup_signal_protection(console)
 
 def save_to_json(timestamp, target, combined_output, analyses):
@@ -520,20 +523,28 @@ def choose_context():
 # ==================== CONTROLE DO PAINEL WEB ====================
 def toggle_web_panel():
     """Ativa ou desativa o painel web."""
-    global WEB_PANEL_PROCESS
+    global WEB_PANEL_PROCESS, WEB_PANEL_LOG
     if WEB_PANEL_PROCESS and WEB_PANEL_PROCESS.poll() is None:
         WEB_PANEL_PROCESS.terminate()
+        if WEB_PANEL_LOG:
+            WEB_PANEL_LOG.close()
         WEB_PANEL_PROCESS = None
+        WEB_PANEL_LOG = None
         console.print("Painel web desativado.", style="bold green")
+        logger.info("Painel web finalizado")
     else:
         # Use -m to run the web panel as a module to avoid import issues
         panel_module = 'web_panel.web_panel'
-        WEB_PANEL_PROCESS = subprocess.Popen([
-            sys.executable,
-            '-m',
-            panel_module,
-        ])
+        log_path = os.path.join(BASE_DIR, 'logs_eventos', 'web_panel.log')
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        WEB_PANEL_LOG = open(log_path, 'a')
+        WEB_PANEL_PROCESS = subprocess.Popen(
+            [sys.executable, '-m', panel_module],
+            stdout=WEB_PANEL_LOG,
+            stderr=subprocess.STDOUT
+        )
         console.print("Painel web disponível em http://localhost:8000", style="bold green")
+        logger.info("Painel web iniciado. Acompanhe o log em %s", log_path)
 
 # ==================== MENU PRINCIPAL ====================
 
@@ -607,3 +618,5 @@ if __name__ == "__main__":
     finally:
         if WEB_PANEL_PROCESS and WEB_PANEL_PROCESS.poll() is None:
             WEB_PANEL_PROCESS.terminate()
+        if WEB_PANEL_LOG:
+            WEB_PANEL_LOG.close()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,22 @@
+import logging
+import os
+from pathlib import Path
+
+LOG_DIR = Path(__file__).resolve().parent.parent / "logs_eventos"
+LOG_DIR.mkdir(exist_ok=True)
+
+
+def setup_logging(name: str) -> logging.Logger:
+    """Return a logger writing to logs_eventos/<name>.log."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        logger.setLevel(logging.INFO)
+        log_file = LOG_DIR / f"{name}.log"
+        handler = logging.FileHandler(log_file)
+        formatter = logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.propagate = False
+    return logger

--- a/utils/scanner_tools.py
+++ b/utils/scanner_tools.py
@@ -3,8 +3,10 @@ import re
 import subprocess
 from datetime import datetime
 from rich.console import Console
+from .logger import setup_logging
 
 console = Console()
+logger = setup_logging("scanner")
 
 # Utility functions
 
@@ -18,6 +20,8 @@ def normalize_target(target: str) -> str:
 
 
 def log_message(msg: str) -> None:
+    """Print message to console and store it in scanner log."""
+    logger.info(msg)
     console.print(f"[bold][{datetime.now().isoformat()}][/bold] {msg}")
 
 


### PR DESCRIPTION
## Summary
- add logging utility and logs_eventos dir
- log scanner activity to file via new logger
- centralize API logging through utils.logger
- suppress web panel output and log to `logs_eventos/web_panel.log`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687067f31044832aa6b591e8c192bc0a