### PR TITLE
Fix OSRFramework fallback command

### DIFF
--- a/utils/scanner_tools.py
+++ b/utils/scanner_tools.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+import shutil
 from datetime import datetime
 from rich.console import Console
 from .logger import setup_logging
@@ -165,12 +166,20 @@ def run_subfind3r(target: str) -> str:
 def run_osrframework(target: str) -> str:
     normalized = normalize_target(target)
     log_message(f"Iniciando OSRFramework para {normalized}")
-    cmd = ["osrsearch","-n",normalized,"-v","-w","osr_output.txt"]
-    try:
-        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
-        return proc.stdout
-    except subprocess.CalledProcessError as e:
-        return f"Erro no OSRFramework: {e.stderr}"
+    commands = [
+        ["osrsearch", "-n", normalized, "-v", "-w", "osr_output.txt"],
+        ["searchfy", "-n", normalized, "-v", "-w", "osr_output.txt"],
+        ["osrf", "searchfy", "-n", normalized, "-v", "-w", "osr_output.txt"],
+        ["osrframework-cli", "searchfy", "-n", normalized, "-v", "-w", "osr_output.txt"],
+    ]
+    for cmd in commands:
+        if shutil.which(cmd[0]):
+            try:
+                proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+                return proc.stdout
+            except subprocess.CalledProcessError as e:
+                return f"Erro no OSRFramework: {e.stderr}"
+    return "OSRFramework não encontrado"
 
 
 def run_knockpy(target: str) -> str:


### PR DESCRIPTION
## Summary
- ensure scanner checks multiple commands when running OSRFramework

## Testing
- `python3 -m py_compile utils/scanner_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68706b34bfc4832aa237639a646c796d