### PR TITLE
Add unified reports with date filter

### DIFF
--- a/web_panel/db_utils.py
+++ b/web_panel/db_utils.py
@@ -69,19 +69,30 @@ def get_record(record_id: int) -> Optional[Dict[str, Any]]:
     }
 
 
-def get_records_by_target(target: str) -> List[Dict[str, Any]]:
-    """Retorna todos os registros de um alvo."""
+def get_records_by_target(
+    target: str, start: Optional[str] = None, end: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """Retorna todos os registros de um alvo.
+
+    Os par\xc3\xa2metros ``start`` e ``end`` s\xc3\xa3o opcionais e permitem filtragem
+    por per\xc3\xadodo de tempo.
+    """
+    query = (
+        "SELECT id, timestamp, client_ip, status, processing_time, data_size,"
+        "       model_used, machine_info, scan_data, analysis_result, ipinfo_data"
+        "  FROM resultscan WHERE ip_dominio_alvo = %s"
+    )
+    params = [target]
+    if start:
+        query += " AND timestamp >= %s"
+        params.append(start)
+    if end:
+        query += " AND timestamp <= %s"
+        params.append(end)
+    query += " ORDER BY id"
+
     with _CONN.cursor() as cur:
-        cur.execute(
-            """
-            SELECT id, timestamp, client_ip, status, processing_time, data_size,
-                   model_used, machine_info, scan_data, analysis_result, ipinfo_data
-              FROM resultscan
-             WHERE ip_dominio_alvo = %s
-             ORDER BY id
-            """,
-            (target,),
-        )
+        cur.execute(query, tuple(params))
         rows = cur.fetchall()
     return [
         {

--- a/web_panel/templates/target_records.html
+++ b/web_panel/templates/target_records.html
@@ -3,6 +3,17 @@
 {% block content %}
 <a href="{{ url_for('targets') }}" class="btn btn-link mb-3">&laquo; Voltar</a>
 <h2>Registros para {{ target }}</h2>
+<form class="row g-3 mb-4" method="get">
+    <div class="col-auto">
+        <input type="date" name="start" value="{{ start }}" class="form-control" placeholder="Data inicial">
+    </div>
+    <div class="col-auto">
+        <input type="date" name="end" value="{{ end }}" class="form-control" placeholder="Data final">
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Filtrar</button>
+    </div>
+</form>
 <table class="table table-striped">
     <thead>
         <tr>
@@ -25,5 +36,6 @@
     {% endfor %}
     </tbody>
 </table>
-<a href="{{ url_for('target_records', target=target, download=1) }}" class="btn btn-primary">Baixar HTML</a>
+<a href="{{ url_for('unified_report', target=target, start=start, end=end) }}" class="btn btn-secondary me-2">Relatório Unificado</a>
+<a href="{{ url_for('target_records', target=target, start=start, end=end, download=1) }}" class="btn btn-primary">Baixar HTML</a>
 {% endblock %}

--- a/web_panel/templates/unified_report.html
+++ b/web_panel/templates/unified_report.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block title %}Relatório Unificado - {{ target }}{% endblock %}
+{% block content %}
+<a href="{{ url_for('target_records', target=target, start=start, end=end) }}" class="btn btn-link mb-3">&laquo; Voltar</a>
+<h2>Relatório Unificado - {{ target }}</h2>
+{% for r in records %}
+<div class="mb-5">
+    <h4>ID {{ r.id }} - {{ r.timestamp }}</h4>
+    <p><strong>Status:</strong> {{ r.status }} | <strong>Pentester:</strong> {{ r.client_ip or '-' }}</p>
+    <h5>Dados do Scan</h5>
+    <pre class="bg-body-secondary p-3 rounded">{{ r.scan_data }}</pre>
+    <h5>Análise da IA</h5>
+    <pre class="bg-body-secondary p-3 rounded">{{ r.analysis_result }}</pre>
+    {% if r.ipinfo_data %}
+    <h5>Dados IPinfo</h5>
+    <pre class="bg-body-secondary p-3 rounded">{{ r.ipinfo_data }}</pre>
+    {% endif %}
+</div>
+{% else %}
+<p>Nenhum registro.</p>
+{% endfor %}
+<a href="{{ url_for('unified_report', target=target, start=start, end=end, download=1) }}" class="btn btn-primary">Baixar HTML</a>
+{% endblock %}

--- a/web_panel/web_panel.py
+++ b/web_panel/web_panel.py
@@ -31,14 +31,43 @@ def create_app():
 
     @app.route('/target/<path:target>')
     def target_records(target: str):
-        records = db.get_records_by_target(target)
+        start = request.args.get('start')
+        end = request.args.get('end')
+        records = db.get_records_by_target(target, start, end)
         if not records:
             abort(404)
         if request.args.get('download'):
-            html = render_template('target_records.html', target=target, records=records)
+            html = render_template(
+                'target_records.html', target=target, records=records, start=start, end=end
+            )
             fname = f"reports_{target}.html"
-            return Response(html, headers={'Content-Disposition': f'attachment; filename={fname}'}, mimetype='text/html')
-        return render_template('target_records.html', target=target, records=records)
+            return Response(
+                html,
+                headers={'Content-Disposition': f'attachment; filename={fname}'},
+                mimetype='text/html',
+            )
+        return render_template(
+            'target_records.html', target=target, records=records, start=start, end=end
+        )
+
+    @app.route('/target/<path:target>/unified')
+    def unified_report(target: str):
+        start = request.args.get('start')
+        end = request.args.get('end')
+        records = db.get_records_by_target(target, start, end)
+        if not records:
+            abort(404)
+        html = render_template(
+            'unified_report.html', target=target, records=records, start=start, end=end
+        )
+        if request.args.get('download'):
+            fname = f"unified_{target}.html"
+            return Response(
+                html,
+                headers={'Content-Disposition': f'attachment; filename={fname}'},
+                mimetype='text/html',
+            )
+        return html
 
     return app
 


### PR DESCRIPTION
## Summary
- support start/end date filters when listing records for a target
- add unified report page that combines all target records
- add filter form and unified-report link in record list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68706e17150c832a823524827d0e8205