### PR TITLE
Improve logging and model load feedback

### DIFF
--- a/API/llm_api_server.py
+++ b/API/llm_api_server.py
@@ -727,6 +727,7 @@ if __name__ == "__main__":
                 console.print("Opção inválida. Tente novamente.", style="bold red")
 
         SELECTED_MODEL = chosen_model
+        logger.info("Modelo selecionado (Ollama): %s", SELECTED_MODEL)
         console.print(f"Modelo selecionado (Ollama): {SELECTED_MODEL}", style="bold cyan")
 
     else:
@@ -771,11 +772,15 @@ if __name__ == "__main__":
 
         HF_DEVICE = 0 if chosen_device == "GPU" else -1
 
+        console.print("[*] Carregando modelo Hugging Face...", style="bold yellow")
+        logger.info("Carregando modelo Hugging Face: %s", HF_MODEL_NAME)
         try:
             load_hf_pipeline(HF_MODEL_NAME, HF_DEVICE)
         except Exception as exc:
+            logger.exception("Falha ao carregar modelo Hugging Face")
             console.print(f"[-] Falha ao carregar modelo Hugging Face: {exc}", style="bold red")
             sys.exit(1)
+        logger.info("Modelo selecionado (Hugging Face): %s (%s)", HF_MODEL_NAME, chosen_device)
         console.print(
             f"Modelo selecionado (Hugging Face): {HF_MODEL_NAME} ({chosen_device})",
             style="bold cyan",
@@ -783,9 +788,11 @@ if __name__ == "__main__":
 
     local_app = create_app()
     try:
+        logger.info("Iniciando servidor na porta %s com backend %s", API_PORT, LLM_BACKEND)
         console.print(f"[+] Iniciando servidor na porta {API_PORT}", style="bold green")
         start_progress_monitor()
         local_app.run(host="0.0.0.0", port=API_PORT, threaded=True)
     except Exception as e:
+        logger.exception("Falha ao iniciar servidor")
         console.print(f"[-] Falha ao iniciar servidor: {str(e)}", style="bold red")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- add log entries when selecting a model and starting the server
- display an explicit message while loading Hugging Face models
- record server startup failures in the log

## Testing
- `python3 -m py_compile API/llm_api_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6870718f85a0832ab119172e36a9b629