### PR TITLE
Integrate AdminLTE dashboard

### DIFF
--- a/web_panel/db_utils.py
+++ b/web_panel/db_utils.py
@@ -110,3 +110,24 @@ def get_records_by_target(
         }
         for r in rows
     ]
+
+def count_records() -> int:
+    """Retorna a quantidade total de registros."""
+    with _CONN.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM resultscan")
+        return cur.fetchone()[0]
+
+
+def count_targets() -> int:
+    """Retorna o número de alvos distintos."""
+    with _CONN.cursor() as cur:
+        cur.execute("SELECT COUNT(DISTINCT ip_dominio_alvo) FROM resultscan")
+        return cur.fetchone()[0]
+
+
+def count_by_status() -> List[Dict[str, Any]]:
+    """Retorna contagem de registros agrupados por status."""
+    with _CONN.cursor() as cur:
+        cur.execute("SELECT status, COUNT(*) FROM resultscan GROUP BY status ORDER BY status")
+        rows = cur.fetchall()
+    return [{"status": r[0], "count": r[1]} for r in rows]

--- a/web_panel/static/js/theme.js
+++ b/web_panel/static/js/theme.js
@@ -2,16 +2,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const toggle = document.getElementById('themeToggle');
     const stored = localStorage.getItem('theme');
     if (stored === 'dark') {
-        document.documentElement.setAttribute('data-bs-theme', 'dark');
-        toggle.checked = true;
+        document.body.classList.add('dark-mode');
+        if (toggle) toggle.checked = true;
     }
-    toggle.addEventListener('change', () => {
-        if (toggle.checked) {
-            document.documentElement.setAttribute('data-bs-theme', 'dark');
-            localStorage.setItem('theme', 'dark');
-        } else {
-            document.documentElement.setAttribute('data-bs-theme', 'light');
-            localStorage.setItem('theme', 'light');
-        }
-    });
+    if (toggle) {
+        toggle.addEventListener('change', () => {
+            if (toggle.checked) {
+                document.body.classList.add('dark-mode');
+                localStorage.setItem('theme', 'dark');
+            } else {
+                document.body.classList.remove('dark-mode');
+                localStorage.setItem('theme', 'light');
+            }
+        });
+    }
 });

--- a/web_panel/templates/base.html
+++ b/web_panel/templates/base.html
@@ -1,31 +1,70 @@
 <!DOCTYPE html>
-<html lang="pt-br" data-bs-theme="light">
+<html lang="pt-br">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}Painel de Relatórios{% endblock %}</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
+    <title>{% block title %}Painel{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/overlayscrollbars@1.13.1/css/OverlayScrollbars.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/css/adminlte.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
-<body>
-    <div class="d-flex">
-        <nav id="sidebar" class="bg-body-tertiary p-3">
-            <h4 class="mb-3">Menu</h4>
-            <ul class="nav nav-pills flex-column mb-auto">
-                <li class="nav-item"><a href="{{ url_for('index') }}" class="nav-link">Registros</a></li>
-                <li class="nav-item"><a href="{{ url_for('targets') }}" class="nav-link">Alvos</a></li>
-            </ul>
-            <hr>
-            <div class="form-check form-switch">
-                <input class="form-check-input" type="checkbox" id="themeToggle">
-                <label class="form-check-label" for="themeToggle">Tema Escuro</label>
+<body class="hold-transition sidebar-mini">
+<div class="wrapper">
+    <!-- Navbar -->
+    <nav class="main-header navbar navbar-expand navbar-white navbar-light">
+        <ul class="navbar-nav">
+            <li class="nav-item">
+                <a class="nav-link" data-widget="pushmenu" href="#" role="button"><i class="fas fa-bars"></i></a>
+            </li>
+        </ul>
+        <ul class="navbar-nav ml-auto">
+            <li class="nav-item">
+                <div class="form-check form-switch mt-2">
+                    <input class="form-check-input" type="checkbox" id="themeToggle">
+                    <label class="form-check-label" for="themeToggle">Tema Escuro</label>
+                </div>
+            </li>
+        </ul>
+    </nav>
+    <!-- Sidebar -->
+    <aside class="main-sidebar sidebar-dark-primary elevation-4">
+        <a href="{{ url_for('index') }}" class="brand-link">
+            <span class="brand-text font-weight-light">PenTest IA</span>
+        </a>
+        <div class="sidebar">
+            <nav class="mt-2">
+                <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu">
+                    <li class="nav-item">
+                        <a href="{{ url_for('index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-table"></i>
+                            <p>Registros</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="{{ url_for('targets') }}" class="nav-link">
+                            <i class="nav-icon fas fa-bullseye"></i>
+                            <p>Alvos</p>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </aside>
+
+    <!-- Content Wrapper -->
+    <div class="content-wrapper">
+        <section class="content pt-3">
+            <div class="container-fluid">
+                {% block content %}{% endblock %}
             </div>
-        </nav>
-        <main class="flex-grow-1 p-4">
-            {% block content %}{% endblock %}
-        </main>
+        </section>
     </div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/overlayscrollbars@1.13.1/js/jquery.overlayScrollbars.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/js/adminlte.min.js"></script>
 <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
 </body>
 </html>

--- a/web_panel/templates/index.html
+++ b/web_panel/templates/index.html
@@ -1,29 +1,91 @@
 {% extends 'base.html' %}
-{% block title %}Registros{% endblock %}
+{% block title %}Dashboard{% endblock %}
 {% block content %}
-<h2 class="mb-4">Registros Recentes</h2>
-<table class="table table-striped">
-    <thead>
-        <tr>
-            <th>ID</th>
-            <th>Data/Hora</th>
-            <th>Pentester</th>
-            <th>Alvo</th>
-            <th>Ações</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for r in records %}
-        <tr>
-            <td>{{ r.id }}</td>
-            <td>{{ r.timestamp }}</td>
-            <td>{{ r.client_ip or '-' }}</td>
-            <td>{{ r.target or '-' }}</td>
-            <td><a href="{{ url_for('view_record', rec_id=r.id) }}">Visualizar</a></td>
-        </tr>
-    {% else %}
-        <tr><td colspan="5">Nenhum registro encontrado.</td></tr>
-    {% endfor %}
-    </tbody>
-</table>
+<div class="row">
+    <div class="col-lg-3 col-6">
+        <div class="small-box bg-info">
+            <div class="inner">
+                <h3>{{ total_records }}</h3>
+                <p>Registros</p>
+            </div>
+            <div class="icon">
+                <i class="fas fa-table"></i>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-3 col-6">
+        <div class="small-box bg-success">
+            <div class="inner">
+                <h3>{{ total_targets }}</h3>
+                <p>Alvos</p>
+            </div>
+            <div class="icon">
+                <i class="fas fa-bullseye"></i>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">Registros por Status</h3>
+            </div>
+            <div class="card-body">
+                <canvas id="statusChart" height="200"></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header">
+        <h3 class="card-title">Registros Recentes</h3>
+    </div>
+    <div class="card-body p-0">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Data/Hora</th>
+                    <th>Pentester</th>
+                    <th>Alvo</th>
+                    <th>Ações</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for r in records %}
+                <tr>
+                    <td>{{ r.id }}</td>
+                    <td>{{ r.timestamp }}</td>
+                    <td>{{ r.client_ip or '-' }}</td>
+                    <td>{{ r.target or '-' }}</td>
+                    <td><a href="{{ url_for('view_record', rec_id=r.id) }}">Visualizar</a></td>
+                </tr>
+            {% else %}
+                <tr><td colspan="5">Nenhum registro encontrado.</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const data = {
+    labels: {{ status_counts | map(attribute='status') | list | tojson }},
+    datasets: [{
+        label: 'Registros',
+        backgroundColor: 'rgba(60,141,188,0.9)',
+        borderColor: 'rgba(60,141,188,1)',
+        data: {{ status_counts | map(attribute='count') | list | tojson }}
+    }]
+};
+new Chart(document.getElementById('statusChart'), {
+    type: 'bar',
+    data: data,
+    options: {responsive: true, maintainAspectRatio: false}
+});
+</script>
 {% endblock %}

--- a/web_panel/templates/report.html
+++ b/web_panel/templates/report.html
@@ -2,27 +2,25 @@
 {% block title %}Relatório{% endblock %}
 {% block content %}
 <a href="{{ url_for('index') }}" class="btn btn-link mb-3">&laquo; Voltar</a>
-<h2>Relatório</h2>
-<div class="mb-3">
-    <strong>ID:</strong> {{ record.id }}<br>
-    <strong>Alvo:</strong> {{ record.target }}<br>
-    <strong>Data:</strong> {{ record.timestamp }}<br>
-    <strong>Status:</strong> {{ record.status }}<br>
-    <strong>Pentester:</strong> {{ record.client_ip }}
+<div class="card">
+    <div class="card-header">
+        <h3 class="card-title">Relatório</h3>
+    </div>
+    <div class="card-body">
+        <p><strong>ID:</strong> {{ record.id }}<br>
+           <strong>Alvo:</strong> {{ record.target }}<br>
+           <strong>Data:</strong> {{ record.timestamp }}<br>
+           <strong>Status:</strong> {{ record.status }}<br>
+           <strong>Pentester:</strong> {{ record.client_ip }}</p>
+        <h5>Dados do Scan</h5>
+        <pre class="bg-light p-3 rounded">{{ record.scan_data }}</pre>
+        <h5>Análise da IA</h5>
+        <pre class="bg-light p-3 rounded">{{ record.analysis_result }}</pre>
+        {% if record.ipinfo_data %}
+        <h5>Dados IPinfo</h5>
+        <pre class="bg-light p-3 rounded">{{ record.ipinfo_data }}</pre>
+        {% endif %}
+        <a href="{{ url_for('view_record', rec_id=record.id, download=1) }}" class="btn btn-primary mt-2">Baixar HTML</a>
+    </div>
 </div>
-<div class="mb-3">
-    <h5>Dados do Scan</h5>
-    <pre class="bg-body-secondary p-3 rounded">{{ record.scan_data }}</pre>
-</div>
-<div class="mb-3">
-    <h5>Análise da IA</h5>
-    <pre class="bg-body-secondary p-3 rounded">{{ record.analysis_result }}</pre>
-</div>
-{% if record.ipinfo_data %}
-<div class="mb-3">
-    <h5>Dados IPinfo</h5>
-    <pre class="bg-body-secondary p-3 rounded">{{ record.ipinfo_data }}</pre>
-</div>
-{% endif %}
-<a href="{{ url_for('view_record', rec_id=record.id, download=1) }}" class="btn btn-primary">Baixar HTML</a>
 {% endblock %}

--- a/web_panel/templates/target_records.html
+++ b/web_panel/templates/target_records.html
@@ -2,40 +2,44 @@
 {% block title %}Registros - {{ target }}{% endblock %}
 {% block content %}
 <a href="{{ url_for('targets') }}" class="btn btn-link mb-3">&laquo; Voltar</a>
-<h2>Registros para {{ target }}</h2>
-<form class="row g-3 mb-4" method="get">
-    <div class="col-auto">
-        <input type="date" name="start" value="{{ start }}" class="form-control" placeholder="Data inicial">
+<div class="card">
+    <div class="card-header">
+        <h3 class="card-title">Registros para {{ target }}</h3>
     </div>
-    <div class="col-auto">
-        <input type="date" name="end" value="{{ end }}" class="form-control" placeholder="Data final">
+    <div class="card-body">
+        <form class="form-inline mb-3" method="get">
+            <div class="form-group mr-2">
+                <input type="date" name="start" value="{{ start }}" class="form-control" placeholder="Data inicial">
+            </div>
+            <div class="form-group mr-2">
+                <input type="date" name="end" value="{{ end }}" class="form-control" placeholder="Data final">
+            </div>
+            <button type="submit" class="btn btn-primary">Filtrar</button>
+        </form>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Data/Hora</th>
+                    <th>Pentester</th>
+                    <th>Ações</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for r in records %}
+                <tr>
+                    <td>{{ r.id }}</td>
+                    <td>{{ r.timestamp }}</td>
+                    <td>{{ r.client_ip or '-' }}</td>
+                    <td><a href="{{ url_for('view_record', rec_id=r.id) }}">Visualizar</a></td>
+                </tr>
+            {% else %}
+                <tr><td colspan="4">Nenhum registro.</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        <a href="{{ url_for('unified_report', target=target, start=start, end=end) }}" class="btn btn-secondary mr-2">Relatório Unificado</a>
+        <a href="{{ url_for('target_records', target=target, start=start, end=end, download=1) }}" class="btn btn-primary">Baixar HTML</a>
     </div>
-    <div class="col-auto">
-        <button type="submit" class="btn btn-primary">Filtrar</button>
-    </div>
-</form>
-<table class="table table-striped">
-    <thead>
-        <tr>
-            <th>ID</th>
-            <th>Data/Hora</th>
-            <th>Pentester</th>
-            <th>Ações</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for r in records %}
-        <tr>
-            <td>{{ r.id }}</td>
-            <td>{{ r.timestamp }}</td>
-            <td>{{ r.client_ip or '-' }}</td>
-            <td><a href="{{ url_for('view_record', rec_id=r.id) }}">Visualizar</a></td>
-        </tr>
-    {% else %}
-        <tr><td colspan="4">Nenhum registro.</td></tr>
-    {% endfor %}
-    </tbody>
-</table>
-<a href="{{ url_for('unified_report', target=target, start=start, end=end) }}" class="btn btn-secondary me-2">Relatório Unificado</a>
-<a href="{{ url_for('target_records', target=target, start=start, end=end, download=1) }}" class="btn btn-primary">Baixar HTML</a>
+</div>
 {% endblock %}

--- a/web_panel/templates/targets.html
+++ b/web_panel/templates/targets.html
@@ -1,12 +1,18 @@
 {% extends 'base.html' %}
 {% block title %}Alvos{% endblock %}
 {% block content %}
-<h2 class="mb-4">Alvos</h2>
-<ul class="list-group">
-{% for t in targets %}
-    <li class="list-group-item"><a href="{{ url_for('target_records', target=t) }}">{{ t }}</a></li>
-{% else %}
-    <li class="list-group-item">Nenhum alvo encontrado.</li>
-{% endfor %}
-</ul>
+<div class="card">
+    <div class="card-header">
+        <h3 class="card-title">Alvos</h3>
+    </div>
+    <div class="card-body p-0">
+        <ul class="list-group list-group-flush">
+        {% for t in targets %}
+            <li class="list-group-item"><a href="{{ url_for('target_records', target=t) }}">{{ t }}</a></li>
+        {% else %}
+            <li class="list-group-item">Nenhum alvo encontrado.</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}

--- a/web_panel/templates/unified_report.html
+++ b/web_panel/templates/unified_report.html
@@ -2,22 +2,28 @@
 {% block title %}Relatório Unificado - {{ target }}{% endblock %}
 {% block content %}
 <a href="{{ url_for('target_records', target=target, start=start, end=end) }}" class="btn btn-link mb-3">&laquo; Voltar</a>
-<h2>Relatório Unificado - {{ target }}</h2>
-{% for r in records %}
-<div class="mb-5">
-    <h4>ID {{ r.id }} - {{ r.timestamp }}</h4>
-    <p><strong>Status:</strong> {{ r.status }} | <strong>Pentester:</strong> {{ r.client_ip or '-' }}</p>
-    <h5>Dados do Scan</h5>
-    <pre class="bg-body-secondary p-3 rounded">{{ r.scan_data }}</pre>
-    <h5>Análise da IA</h5>
-    <pre class="bg-body-secondary p-3 rounded">{{ r.analysis_result }}</pre>
-    {% if r.ipinfo_data %}
-    <h5>Dados IPinfo</h5>
-    <pre class="bg-body-secondary p-3 rounded">{{ r.ipinfo_data }}</pre>
-    {% endif %}
+<div class="card">
+    <div class="card-header">
+        <h3 class="card-title">Relatório Unificado - {{ target }}</h3>
+    </div>
+    <div class="card-body">
+        {% for r in records %}
+        <div class="mb-4">
+            <h5>ID {{ r.id }} - {{ r.timestamp }}</h5>
+            <p><strong>Status:</strong> {{ r.status }} | <strong>Pentester:</strong> {{ r.client_ip or '-' }}</p>
+            <h6>Dados do Scan</h6>
+            <pre class="bg-light p-3 rounded">{{ r.scan_data }}</pre>
+            <h6>Análise da IA</h6>
+            <pre class="bg-light p-3 rounded">{{ r.analysis_result }}</pre>
+            {% if r.ipinfo_data %}
+            <h6>Dados IPinfo</h6>
+            <pre class="bg-light p-3 rounded">{{ r.ipinfo_data }}</pre>
+            {% endif %}
+        </div>
+        {% else %}
+        <p>Nenhum registro.</p>
+        {% endfor %}
+        <a href="{{ url_for('unified_report', target=target, start=start, end=end, download=1) }}" class="btn btn-primary">Baixar HTML</a>
+    </div>
 </div>
-{% else %}
-<p>Nenhum registro.</p>
-{% endfor %}
-<a href="{{ url_for('unified_report', target=target, start=start, end=end, download=1) }}" class="btn btn-primary">Baixar HTML</a>
 {% endblock %}

--- a/web_panel/web_panel.py
+++ b/web_panel/web_panel.py
@@ -11,7 +11,16 @@ def create_app():
     @app.route('/')
     def index():
         records = db.list_records()
-        return render_template('index.html', records=records)
+        total_records = db.count_records()
+        total_targets = db.count_targets()
+        status_counts = db.count_by_status()
+        return render_template(
+            'index.html',
+            records=records,
+            total_records=total_records,
+            total_targets=total_targets,
+            status_counts=status_counts,
+        )
 
     @app.route('/record/<int:rec_id>')
     def view_record(rec_id: int):


### PR DESCRIPTION
## Summary
- restyle templates with AdminLTE theme
- add dark mode toggle script compatible with AdminLTE
- show summary boxes and chart on dashboard
- implement counts in `db_utils`
- update flask routes to provide new data

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e5df56f0832a813c3d25859e3a58