### PR TITLE
Add theme toggle and filter options

### DIFF
--- a/web_panel/db_utils.py
+++ b/web_panel/db_utils.py
@@ -131,3 +131,50 @@ def count_by_status() -> List[Dict[str, Any]]:
         cur.execute("SELECT status, COUNT(*) FROM resultscan GROUP BY status ORDER BY status")
         rows = cur.fetchall()
     return [{"status": r[0], "count": r[1]} for r in rows]
+
+
+def list_attackers() -> List[str]:
+    """Retorna lista de atacantes/pentesters distintos."""
+    with _CONN.cursor() as cur:
+        cur.execute("SELECT DISTINCT client_ip FROM resultscan ORDER BY client_ip")
+        return [row[0] for row in cur.fetchall()]
+
+
+def filter_records(
+    target: Optional[str] = None,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    attacker: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Filtra registros de acordo com os parâmetros fornecidos."""
+    query = (
+        "SELECT id, timestamp, client_ip, ip_dominio_alvo "
+        "FROM resultscan WHERE 1=1"
+    )
+    params = []
+    if target:
+        query += " AND ip_dominio_alvo = %s"
+        params.append(target)
+    if attacker:
+        query += " AND client_ip = %s"
+        params.append(attacker)
+    if start:
+        query += " AND timestamp >= %s"
+        params.append(start)
+    if end:
+        query += " AND timestamp <= %s"
+        params.append(end)
+    query += " ORDER BY id DESC"
+
+    with _CONN.cursor() as cur:
+        cur.execute(query, tuple(params))
+        rows = cur.fetchall()
+    return [
+        {
+            "id": r[0],
+            "timestamp": r[1],
+            "client_ip": r[2],
+            "target": r[3],
+        }
+        for r in rows
+    ]

--- a/web_panel/templates/index.html
+++ b/web_panel/templates/index.html
@@ -44,6 +44,34 @@
         <h3 class="card-title">Registros Recentes</h3>
     </div>
     <div class="card-body p-0">
+        <form class="form-inline m-2" method="get">
+            <div class="form-group mr-2">
+                <select name="target" class="form-control">
+                    <option value="">Todos os Alvos</option>
+                    {% for t in targets %}
+                        <option value="{{ t }}" {% if filters.target == t %}selected{% endif %}>{{ t }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="form-group mr-2">
+                <select name="attacker" class="form-control">
+                    <option value="">Todos os Pentesters</option>
+                    {% for a in attackers %}
+                        <option value="{{ a }}" {% if filters.attacker == a %}selected{% endif %}>{{ a }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="form-group mr-2">
+                <input type="date" name="start" value="{{ filters.start }}" class="form-control" placeholder="Data inicial">
+            </div>
+            <div class="form-group mr-2">
+                <input type="date" name="end" value="{{ filters.end }}" class="form-control" placeholder="Data final">
+            </div>
+            <button type="submit" class="btn btn-primary">Filtrar</button>
+            {% if filters.target or filters.start or filters.end or filters.attacker %}
+                <a href="{{ url_for('index') }}" class="btn btn-secondary ml-2">Limpar</a>
+            {% endif %}
+        </form>
         <table class="table table-striped">
             <thead>
                 <tr>

--- a/web_panel/web_panel.py
+++ b/web_panel/web_panel.py
@@ -10,7 +10,14 @@ def create_app():
 
     @app.route('/')
     def index():
-        records = db.list_records()
+        target = request.args.get('target')
+        start = request.args.get('start')
+        end = request.args.get('end')
+        attacker = request.args.get('attacker')
+        if any([target, start, end, attacker]):
+            records = db.filter_records(target, start, end, attacker)
+        else:
+            records = db.list_records()
         total_records = db.count_records()
         total_targets = db.count_targets()
         status_counts = db.count_by_status()
@@ -20,6 +27,14 @@ def create_app():
             total_records=total_records,
             total_targets=total_targets,
             status_counts=status_counts,
+            targets=db.list_targets(),
+            attackers=db.list_attackers(),
+            filters={
+                'target': target,
+                'start': start,
+                'end': end,
+                'attacker': attacker,
+            },
         )
 
     @app.route('/record/<int:rec_id>')


### PR DESCRIPTION
## Summary
- add ability to filter records on dashboard by target, attacker and date range
- expose helper `filter_records` and `list_attackers` in `db_utils`
- include filter values when rendering index template
- keep built-in dark/light mode toggle from AdminLTE example

## Testing
- `python -m py_compile web_panel/db_utils.py web_panel/web_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_6873e7bcfbec832a8447f9833164563d