### PR TITLE
Improve theme toggle icons

### DIFF
--- a/web_panel/static/js/theme.js
+++ b/web_panel/static/js/theme.js
@@ -1,18 +1,36 @@
 document.addEventListener('DOMContentLoaded', () => {
     const toggle = document.getElementById('themeToggle');
+    const icon = document.getElementById('themeIcon');
     const stored = localStorage.getItem('theme');
+
     if (stored === 'dark') {
         document.body.classList.add('dark-mode');
         if (toggle) toggle.checked = true;
+        if (icon) {
+            icon.classList.remove('fa-sun');
+            icon.classList.add('fa-moon');
+        }
+    } else if (icon) {
+        icon.classList.remove('fa-moon');
+        icon.classList.add('fa-sun');
     }
+
     if (toggle) {
         toggle.addEventListener('change', () => {
             if (toggle.checked) {
                 document.body.classList.add('dark-mode');
                 localStorage.setItem('theme', 'dark');
+                if (icon) {
+                    icon.classList.remove('fa-sun');
+                    icon.classList.add('fa-moon');
+                }
             } else {
                 document.body.classList.remove('dark-mode');
                 localStorage.setItem('theme', 'light');
+                if (icon) {
+                    icon.classList.remove('fa-moon');
+                    icon.classList.add('fa-sun');
+                }
             }
         });
     }

--- a/web_panel/templates/base.html
+++ b/web_panel/templates/base.html
@@ -22,7 +22,9 @@
             <li class="nav-item">
                 <div class="form-check form-switch mt-2">
                     <input class="form-check-input" type="checkbox" id="themeToggle">
-                    <label class="form-check-label" for="themeToggle">Tema Escuro</label>
+                    <label class="form-check-label" for="themeToggle">
+                        <i id="themeIcon" class="fas fa-sun"></i>
+                    </label>
                 </div>
             </li>
         </ul>


### PR DESCRIPTION
## Summary
- replace text label with icon in base layout
- update JavaScript to switch sun/moon icons based on selected theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f37e93d8832a99abe3036148ace5